### PR TITLE
use LoopVectorization and custom single pass newton's method to speed up `irr` 2x to 5x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 
 [compat]
+LoopVectorization = "^0.12"
 Roots = "^1.0, 2"
 julia = "1.6"
 

--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,12 @@ authors = ["alecloudenback <alecloudenback@users.noreply.github.com> and contrib
 version = "1.0.1"
 
 [deps]
+LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 
 [compat]
-julia = "1.6"
 Roots = "^1.0, 2"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/FinanceCore.jl
+++ b/src/FinanceCore.jl
@@ -1,5 +1,6 @@
 module FinanceCore
 import Roots
+using LoopVectorization
 
 include("AbtractYield.jl")
 

--- a/src/irr.jl
+++ b/src/irr.jl
@@ -54,7 +54,6 @@ function irr_robust(cashflows, times)
 
 end
 
-irr_newton(cashflows) = irr_newton(cashflows,0:length(cashflows)-1)
 
 function irr_newton(cashflows, times)
     @assert length(cashflows) >= length(times)

--- a/test/irr.jl
+++ b/test/irr.jl
@@ -28,8 +28,8 @@ p(rate) = Periodic(rate,1)
     @test irr([-100,100]) ≈ p(0.)
     @test isnothing(irr([100,100])) # answer is -1, but search range won't find it
     
-    # test an infinite irr
-    @test rate(irr([-1e8,0.,0.,0.],0:3)) == Inf
+    # test the unsolvable
+    @test isnothing(irr([-1e8,0.,0.,0.],0:3))
 
 end
 

--- a/test/irr.jl
+++ b/test/irr.jl
@@ -28,8 +28,8 @@ p(rate) = Periodic(rate,1)
     @test irr([-100,100]) ≈ p(0.)
     @test isnothing(irr([100,100])) # answer is -1, but search range won't find it
     
-    # test the unsolvable
-    @test isnothing(irr([-1e8,0.,0.,0.],0:3))
+    # test an infinite irr
+    @test rate(irr([-1e8,0.,0.,0.],0:3)) == Inf
 
 end
 


### PR DESCRIPTION
```julia
# original
julia> @benchmark irr($cfs,0:50)
BenchmarkTools.Trial: 10000 samples with 7 evaluations.
 Range (min … max):  4.494 μs …  12.649 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     4.643 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   4.757 μs ± 420.592 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▃  ▃█▁▂▂▁                                                   ▁
  █▆▂██████▆▆▆▇█▆▆▆▆█▇▆▇▇▇▇▆▇▇▇▆▆▆▆▆▇▇▆▅▅▆▅▆▅▆▅▅▅▄▅▄▅▄▅▅▅▆▆▆▆ █
  4.49 μs      Histogram: log(frequency) by time      6.48 μs <

 Memory estimate: 32 bytes, allocs estimate: 1.

julia> @benchmark irr($v[1:3])
BenchmarkTools.Trial: 10000 samples with 192 evaluations.
 Range (min … max):  509.115 ns …  14.000 μs  ┊ GC (min … max): 0.00% … 95.37%
 Time  (median):     529.297 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   545.506 ns ± 261.249 ns  ┊ GC (mean ± σ):  0.94% ±  1.90%

  ▂▄▄▃ ▁▇█▆▄▄▁▁▃▃▂▁▁▁  ▁    ▂▂▂▁  ▁▁▁                           ▂
  ████▇██████████████████▇▇██████▇████▇▇▇▇▇▇▇▇▇█▆▅▆▆▆▅▅▆▅▆▅▅▅▅▅ █
  509 ns        Histogram: log(frequency) by time        670 ns <

 Memory estimate: 112 bytes, allocs estimate: 2.

# new 

julia> @benchmark irr($cfs,0:50)
BenchmarkTools.Trial: 10000 samples with 134 evaluations.
 Range (min … max):  722.634 ns …  16.890 μs  ┊ GC (min … max): 0.00% … 94.91%
 Time  (median):     744.403 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   751.382 ns ± 166.466 ns  ┊ GC (mean ± σ):  0.21% ±  0.95%

  █▃▄▂  █▅▅▃▁  ▃ ▁                                              ▂
  ████████████▇███▇██▇▇▇▇▇▆▇▇▆▆▅▇▇▇▇█▇▇▇▇▆▆▆▆▆▆▆▇▇▆▆▅▅▅▅▅▅▄▄▄▄▆ █
  723 ns        Histogram: log(frequency) by time        935 ns <

 Memory estimate: 32 bytes, allocs estimate: 1.

julia> @benchmark irr($v[1:3])
BenchmarkTools.Trial: 10000 samples with 570 evaluations.
 Range (min … max):  204.751 ns …   5.397 μs  ┊ GC (min … max): 0.00% … 95.17%
 Time  (median):     206.505 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   219.286 ns ± 181.659 ns  ┊ GC (mean ± σ):  3.07% ±  3.56%

  ▇█▄▁▁▂▅▆▂   ▂▃                           ▁                    ▁
  ████████████████▇▇▇████▇▇██████▇█████▇█████▇▇▇▆▇▆▆▇▆▆▆▅▅▆▅▅▄▆ █
  205 ns        Histogram: log(frequency) by time        263 ns <

 Memory estimate: 112 bytes, allocs estimate: 2.
```