### PR TITLE
Deduplicate IRR internals via Cashflow decomposition

### DIFF
--- a/ext/FinanceCoreLoopVectorizationExt.jl
+++ b/ext/FinanceCoreLoopVectorizationExt.jl
@@ -1,7 +1,7 @@
 module FinanceCoreLoopVectorizationExt
 
 using FinanceCore
-using FinanceCore: TurboBackend, VECTORIZATION_BACKEND, Cashflow, amount, timepoint
+using FinanceCore: TurboBackend, VECTORIZATION_BACKEND
 using LoopVectorization
 
 # Set the backend to TurboBackend when this extension loads
@@ -16,19 +16,6 @@ function FinanceCore.__pv_div_pv′(::TurboBackend, r, cashflows, times)
     @turbo warn_check_args = false for i in eachindex(cashflows)
         cf = cashflows[i]
         t = times[i]
-        a = cf * exp(-r * t)
-        n += a
-        d += a * -t
-    end
-    return n / d
-end
-
-function FinanceCore.__pv_div_pv′(::TurboBackend, r, cashflows::Vector{C}) where {C <: Cashflow}
-    n = 0.0
-    d = 0.0
-    @turbo warn_check_args = false for i in eachindex(cashflows)
-        cf = amount(cashflows[i])
-        t = timepoint(cashflows[i])
         a = cf * exp(-r * t)
         n += a
         d += a * -t

--- a/src/irr.jl
+++ b/src/irr.jl
@@ -49,7 +49,7 @@ function irr_robust(cashflows, times)
     M = maximum(abs, cashflows)
     iszero(M) && return nothing
     normalized = cashflows ./ M
-    f(r) = present_value(Continuous(r), normalized, times)
+    f(r) = sum(cf * exp(-r * t) for (cf, t) in zip(normalized, times))
     # operate in continuous rate space to avoid the singularity at i = -1
     # in periodic space (where (1+i)^t is undefined for fractional t)
     roots = Roots.find_zeros(f, -5.0, 3.0)
@@ -58,7 +58,7 @@ function irr_robust(cashflows, times)
     isempty(roots) && return nothing
     # find the root nearest zero and convert back to periodic rate
     min_i = argmin(abs.(roots))
-    return Periodic(Continuous(roots[min_i]), 1)
+    return Periodic(exp(roots[min_i]) - 1, 1)
 
 end
 
@@ -73,7 +73,7 @@ function irr_newton(cashflows, times)
         1.0e-9,
         100
     )
-    return Periodic(Continuous(r), 1)
+    return Periodic(exp(r) - 1, 1)
 
 end
 

--- a/src/irr.jl
+++ b/src/irr.jl
@@ -23,16 +23,9 @@ function internal_rate_of_return(cashflows::AbstractVector{<:Real})
 end
 
 function internal_rate_of_return(cashflows::Vector{C}) where {C <: Cashflow}
-    # first try to quickly solve with newton's method, otherwise
-    # revert to a more robust method
-
-    v = irr_newton(cashflows)
-
-    if isnan(rate(v))
-        return irr_robust(cashflows)
-    else
-        return v
-    end
+    amounts = amount.(cashflows)
+    times = timepoint.(cashflows)
+    return internal_rate_of_return(amounts, times)
 end
 
 function internal_rate_of_return(cashflows, times)
@@ -56,7 +49,7 @@ function irr_robust(cashflows, times)
     M = maximum(abs, cashflows)
     iszero(M) && return nothing
     normalized = cashflows ./ M
-    f(r) = sum(cf * exp(-r * t) for (cf, t) in zip(normalized, times))
+    f(r) = present_value(Continuous(r), normalized, times)
     # operate in continuous rate space to avoid the singularity at i = -1
     # in periodic space (where (1+i)^t is undefined for fractional t)
     roots = Roots.find_zeros(f, -5.0, 3.0)
@@ -65,21 +58,7 @@ function irr_robust(cashflows, times)
     isempty(roots) && return nothing
     # find the root nearest zero and convert back to periodic rate
     min_i = argmin(abs.(roots))
-    return Periodic(exp(roots[min_i]) - 1, 1)
-
-end
-
-function irr_robust(cashflows::Vector{C}) where {C <: Cashflow}
-    M = maximum(cf -> abs(amount(cf)), cashflows)
-    iszero(M) && return nothing
-    f(r) = sum(amount(cf) / M * exp(-r * timepoint(cf)) for cf in cashflows)
-    roots = Roots.find_zeros(f, -5.0, 3.0)
-
-    # short circuit and return nothing if no roots found
-    isempty(roots) && return nothing
-    # find the root nearest zero and convert back to periodic rate
-    min_i = argmin(abs.(roots))
-    return Periodic(exp(roots[min_i]) - 1, 1)
+    return Periodic(Continuous(roots[min_i]), 1)
 
 end
 
@@ -94,19 +73,7 @@ function irr_newton(cashflows, times)
         1.0e-9,
         100
     )
-    return Periodic(exp(r) - 1, 1)
-
-end
-
-function irr_newton(cashflows::Vector{C}) where {C <: Cashflow}
-    # use newton's method with hand-coded derivative
-    r = __newtons_method1D_irr(
-        cashflows,
-        0.001,
-        1.0e-9,
-        100
-    )
-    return Periodic(exp(r) - 1, 1)
+    return Periodic(Continuous(r), 1)
 
 end
 
@@ -129,10 +96,6 @@ function __pv_div_pv′(r, cashflows, times)
     return __pv_div_pv′(VECTORIZATION_BACKEND[], r, cashflows, times)
 end
 
-function __pv_div_pv′(r, cashflows::Vector{C}) where {C <: Cashflow}
-    return __pv_div_pv′(VECTORIZATION_BACKEND[], r, cashflows)
-end
-
 # Base @simd implementation
 function __pv_div_pv′(::SimdBackend, r, cashflows, times)
     n = 0.0
@@ -140,19 +103,6 @@ function __pv_div_pv′(::SimdBackend, r, cashflows, times)
     @inbounds @simd for i in eachindex(cashflows)
         cf = cashflows[i]
         t = times[i]
-        a = cf * exp(-r * t)
-        n += a
-        d += a * -t
-    end
-    return n / d
-end
-
-function __pv_div_pv′(::SimdBackend, r, cashflows::Vector{C}) where {C <: Cashflow}
-    n = 0.0
-    d = 0.0
-    @inbounds @simd for i in eachindex(cashflows)
-        cf = amount(cashflows[i])
-        t = timepoint(cashflows[i])
         a = cf * exp(-r * t)
         n += a
         d += a * -t
@@ -176,18 +126,6 @@ function __newtons_method1D_irr(cashflows, times, x, ε, k_max)
     while abs(Δ) > ε && k ≤ k_max
         # @show x,H(x),  ∇f(x)
         Δ = __pv_div_pv′(x, cashflows, times)
-        x -= Δ
-        k += 1
-    end
-    return x
-end
-
-function __newtons_method1D_irr(cashflows::Vector{C}, x, ε, k_max) where {C <: Cashflow}
-    k = 1
-    Δ = Inf
-    while abs(Δ) > ε && k ≤ k_max
-        # @show x,H(x),  ∇f(x)
-        Δ = __pv_div_pv′(x, cashflows)
         x -= Δ
         k += 1
     end


### PR DESCRIPTION
## Summary

- The `Cashflow` entry point now extracts `amount.(cashflows)` and `timepoint.(cashflows)` once, then delegates to the `(cashflows, times)` path — eliminating 5 parallel `Vector{Cashflow}`-specific method bodies (~60 lines removed, net -75 lines)
- `irr_robust` NPV computation replaced with `present_value(Continuous(r), normalized, times)`, making it explicit that IRR finds the rate where PV = 0
- Manual `Periodic(exp(r) - 1, 1)` conversions replaced with `Periodic(Continuous(r), 1)`, using the existing rate conversion infrastructure

The SIMD/turbo inner loops for Newton's method (`__pv_div_pv′`) are unchanged — they compute PV and its derivative jointly in a single pass, which has no semantic equivalent in the `present_value` API.

### Before (call graph)
```
internal_rate_of_return(cfs::Vector{<:Cashflow})
  ├─ irr_newton(cfs::Vector{<:Cashflow})          ← duplicate
  │   └─ __newtons_method1D_irr(cfs::Vector{<:Cashflow}, ...) ← duplicate
  │       └─ __pv_div_pv′(r, cfs::Vector{<:Cashflow})        ← duplicate
  │           └─ __pv_div_pv′(::Backend, r, cfs::Vector{<:Cashflow}) ← duplicate
  └─ irr_robust(cfs::Vector{<:Cashflow})           ← duplicate
```

### After
```
internal_rate_of_return(cfs::Vector{<:Cashflow})    ← decompose & delegate
  └─ internal_rate_of_return(amounts, times)         ← single path for everything
      ├─ irr_newton(cashflows, times)
      │   └─ __newtons_method1D_irr(cashflows, times, ...)
      │       └─ __pv_div_pv′(backend, r, cashflows, times)
      └─ irr_robust(cashflows, times)
          └─ present_value(Continuous(r), normalized, times)
```

## Test plan

- [x] All 171 existing tests pass (`Pkg.test()`)
- [x] Cashflow-based IRR tests exercise the new decompose-and-delegate path
- [x] Edge cases (zero cashflows, unsolvable, multiple roots) unchanged
- [x] Challenging 100-element and 51-element vectors pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)