### PR TITLE
Fix doc CI: backtick interval notation in irr docstring

### DIFF
--- a/src/irr.jl
+++ b/src/irr.jl
@@ -16,7 +16,7 @@ Periodic(0.1, 1)
 ```
 
 # Solver notes
-First tries Newton's method (fast). If Newton does not converge, falls back to a robust root-finding search in continuous rate space over [-5, 3] (approximately [-0.993, 19.1] in periodic rate). When the fallback finds multiple roots, returns the one nearest zero.
+First tries Newton's method (fast). If Newton does not converge, falls back to a robust root-finding search in continuous rate space over `[-5, 3]` (approximately `[-0.993, 19.1]` in periodic rate). When the fallback finds multiple roots, returns the one nearest zero.
 """
 function internal_rate_of_return(cashflows::AbstractVector{<:Real})
     return internal_rate_of_return(cashflows, 0:(length(cashflows) - 1))


### PR DESCRIPTION
## Summary

Documenter parses `[-5, 3] (approximately [-0.993, 19.1] in periodic rate)` in the `internal_rate_of_return` docstring as a markdown link `[text](url)` because of the `[...] (...)` juxtaposition. This has been breaking the downstream `ActuaryUtilities.jl` doc CI since this docstring landed in #35 (commit `18263b6`, *Move irr_robust to continuous rate space*) — the most recent successful AU doc build was 2026-03-19, before that merge.

Wrapping each interval in backticks makes them inline code spans, which escapes the brackets from link parsing and is the more conventional way to display numeric intervals in API docs anyway.

```diff
-First tries Newton's method (fast). If Newton does not converge, falls back to a robust root-finding search in continuous rate space over [-5, 3] (approximately [-0.993, 19.1] in periodic rate). When the fallback finds multiple roots, returns the one nearest zero.
+First tries Newton's method (fast). If Newton does not converge, falls back to a robust root-finding search in continuous rate space over `[-5, 3]` (approximately `[-0.993, 19.1]` in periodic rate). When the fallback finds multiple roots, returns the one nearest zero.
```

## Test plan

- [x] No code changed — pure docstring edit, no test impact
- [ ] Doc CI on this PR passes
- [ ] Verify downstream `ActuaryUtilities.jl#134` doc CI then passes once this is merged + tagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)