### PR TITLE
Make `irr` a const binding

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FinanceCore"
 uuid = "b9b1ffdd-6612-4b69-8227-7663be06e089"
-version = "2.5.2"
+version = "2.5.3"
 authors = ["alecloudenback <alecloudenback@users.noreply.github.com> and contributors"]
 
 [deps]

--- a/src/irr.jl
+++ b/src/irr.jl
@@ -166,7 +166,7 @@ end
 
     An alias for `internal_rate_of_return`.
 """
-irr = internal_rate_of_return
+const irr = internal_rate_of_return
 
 # modified from
 # Algorithms for Optimization, Mykel J. Kochenderfer and Tim A. Wheeler, pg 88


### PR DESCRIPTION
## Summary

`irr` was defined as a non-const global alias (`irr = internal_rate_of_return` at `src/irr.jl:169`). Because the binding is mutable, every external caller that references `FinanceCore.irr` reads it as `::Any` at the call site and inference collapses from that point forward — even though the underlying `internal_rate_of_return` is itself type-stable.

This was surfaced by @brandonleewis: inside `Capital.BSCR.solve_oas`, the unqualified `irr(...)` call produced `Body::Any` with `cof::Any` and `s::Any`, propagating into every downstream consumer of the result.

The one-character fix (`irr` → `const irr`) matches the existing pattern for the `pv` alias in `src/pv.jl:40` (`const pv = present_value`).

### Impact on a downstream caller

Test program: `f(cfs) = (r = irr(cfs); rate(r) * 2 + 1.0)`

|                  | Before (non-const) | After (const)          |
|------------------|--------------------|------------------------|
| Binding lookup   | `::Any`            | `Core.Const(...)`      |
| `r`              | `::Any`            | `Rate{Float64,Periodic}` |
| Return type      | `Body::Any`        | `Body::Float64`        |
| Allocs / bytes   | 4 / 80 B per call  | 0 / 0                  |
| Median time      | 264 ns             | 216 ns                 |
| Tail (max)       | 21.0 µs (98% GC)   | 427 ns                 |

The pre-fix tail is the real cost: every boxed `::Any` intermediate allocates, and in a hot loop those allocations produce GC pauses.

This is invisible to FinanceCore's own test suite because internal call paths use `internal_rate_of_return` directly; only external `using FinanceCore; irr(...)` sites are affected.

## Test plan

- [x] `Pkg.test("FinanceCore")` — all 171 tests pass
- [x] `@code_warntype f() = FinanceCore.irr` returns `Body::typeof(internal_rate_of_return)` (was `Body::Any`)
- [x] Downstream caller `@code_warntype` shows fully concrete inference (no `::Any`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)