### PR TITLE
Breaking (v3.0.0): irr returns Periodic(NaN,1) instead of nothing — alternative to #38

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,9 +36,10 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v5
         with:
           files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
       - uses: julia-actions/julia-downgrade-compat@v1
         if: ${{ matrix.version == '1.10' }}
         with:

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FinanceCore"
 uuid = "b9b1ffdd-6612-4b69-8227-7663be06e089"
-version = "2.5.4"
+version = "3.0.0"
 authors = ["alecloudenback <alecloudenback@users.noreply.github.com> and contributors"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FinanceCore"
 uuid = "b9b1ffdd-6612-4b69-8227-7663be06e089"
-version = "2.5.3"
+version = "2.5.4"
 authors = ["alecloudenback <alecloudenback@users.noreply.github.com> and contributors"]
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -13,16 +13,13 @@ If you are extending a function or type as a user or developer, then it would be
 
 ## FinanceCore contents
 
-### Reexported by ActuaryUtilities.jl
-- `irr` and `internal_rate_of_return` (reexported by ActuaryUtilities)
-
-### Reexported by FinanceModels.jl
-- `Rate`s and `Frequency`s
+- `Rate`s and `Frequency`s (`Periodic`, `Continuous`)
 - `discount`, `accumulation`, and `forward` functions
+- `Cashflow`, `Quote`, and `Composite` contracts with the `amount`/`timepoint`/`maturity` accessors
+- `irr`/`internal_rate_of_return` and `pv`/`present_value`
 
-### Used by multiple packages
-- `cashflows` and `timepoints` functions
+FinanceCore exports these names, and downstream packages (FinanceModels.jl via `@reexport`, ActuaryUtilities.jl selectively) re-export them — so `using FinanceModels` or `using ActuaryUtilities` brings the FinanceCore API into scope without loading FinanceCore directly.
 
-# TODO
-- What's the best pattern for exports? Should this package export anything and have dependent packages @reexport? Does that make it so users would still see `Yields.Rate`?
-- Should this package precompile anything, or let the downstream packages do that? Or do it here unless the downstream extend the types and/or methods?
+## Upgrading to v3
+
+`internal_rate_of_return`/`irr` now return `Periodic(NaN, 1)` instead of `nothing` when no root is found, so the return type is always a `Rate`. Replace `isnothing(irr(cfs))` checks with `isnan(rate(irr(cfs)))`.

--- a/ext/FinanceCoreLoopVectorizationExt.jl
+++ b/ext/FinanceCoreLoopVectorizationExt.jl
@@ -4,7 +4,6 @@ using FinanceCore
 using FinanceCore: TurboBackend, VECTORIZATION_BACKEND, Cashflow, amount, timepoint
 using LoopVectorization
 
-# Set the backend to TurboBackend when this extension loads
 function __init__()
     return VECTORIZATION_BACKEND[] = TurboBackend()
 end

--- a/src/Contracts.jl
+++ b/src/Contracts.jl
@@ -38,12 +38,12 @@ Base.isapprox(a::Quote, b::Quote) = isapprox(a.price, b.price) && isapprox(a.ins
 """
     Cashflow(amount,time)
 
-A `Cahflow{A,B}` is a contract that pays an `amount` at `time`. 
+A `Cashflow{A,B}` is a contract that pays an `amount` at `time`.
 
 Cashflows can be:
 
 - negated with the unary `-` operator. 
-- added/subtracted together but note that the `time` must be `isapprox` equal.
+- added/subtracted together but note that the `time` must be `isapprox` equal (default `isapprox` tolerance, i.e. relative to the magnitude of the times).
 - multiplied/divided by a scalar.
 
 Supertype Hierarchy
@@ -63,7 +63,7 @@ Base.zero(c::C) where {C <: Cashflow} = Cashflow(zero(c.amount), c.time)
 """
     amount(x)
 
-If is an object with an amount component (e.g. a `Cashflow`), will retrun that amount component, otherwise just `x`.
+If `x` is an object with an amount component (e.g. a `Cashflow`), will return that amount component, otherwise just `x`.
 
 # Examples
 
@@ -100,13 +100,17 @@ timepoint(x::R, t) where {R <: Real} = t
 
 # Base.convert(::Type{Cashflow{A,B}}, y::Cashflow{C,D}) where {A,B,C,D} = Cashflow(A(y.amount), B(y.time))
 
+# `isapprox` has no methods for `Dates.Date`, so Date timepoints compare exactly
+__time_isapprox(a, b; kwargs...) = isapprox(a, b; kwargs...)
+__time_isapprox(a::Dates.Date, b::Dates.Date; kwargs...) = a == b
+
 function Base.isapprox(a::C, b::D; atol::Real = 0, rtol::Real = atol > 0 ? 0 : √eps()) where {C <: Cashflow, D <: Cashflow}
     amt = isapprox(amount(a), amount(b); atol, rtol)
-    return amt && isapprox(timepoint(a), timepoint(b); atol, rtol)
+    return amt && __time_isapprox(timepoint(a), timepoint(b); atol, rtol)
 end
 
 function Base.:+(c1::C, c2::D) where {C <: Cashflow, D <: Cashflow}
-    return if timepoint(c1) ≈ timepoint(c2)
+    return if __time_isapprox(timepoint(c1), timepoint(c2))
         Cashflow(amount(c1) + amount(c2), timepoint(c1))
     else
         throw(ArgumentError("Cashflow timepoints must be the same. Got $(timepoint(c1)) and $(timepoint(c2))."))
@@ -114,7 +118,7 @@ function Base.:+(c1::C, c2::D) where {C <: Cashflow, D <: Cashflow}
 end
 
 function Base.:-(c1::C, c2::D) where {C <: Cashflow, D <: Cashflow}
-    return if timepoint(c1) ≈ timepoint(c2)
+    return if __time_isapprox(timepoint(c1), timepoint(c2))
         Cashflow(amount(c1) - amount(c2), timepoint(c1))
     else
         throw(ArgumentError("Cashflow timepoints must be the same. Got $(timepoint(c1)) and $(timepoint(c2))."))

--- a/src/Rates.jl
+++ b/src/Rates.jl
@@ -60,6 +60,12 @@ See also: [`Continuous`](@ref)
 """
 struct Periodic <: Frequency
     frequency::Int
+    function Periodic(frequency::Int)
+        # frequency 0 would silently produce NaN rates (0 * log(Inf)); negative
+        # frequencies invert the compounding math without meaning
+        frequency > 0 || throw(ArgumentError("Periodic compounding frequency must be a positive integer, got $frequency"))
+        return new(frequency)
+    end
 end
 
 function Periodic(frequency::T) where {T <: AbstractFloat}
@@ -180,14 +186,14 @@ Returns a `Rate` with an equivalent discount but represented with a different co
 # Examples
 
 ```julia-repl
-julia> r = Rate(Periodic(12),0.01)
-Rate(0.01, Periodic(12))
+julia> r = Rate(0.01, Periodic(12))
+Periodic(0.009999999999998899, 12)
 
-julia> convert(Periodic(1),r)
-Rate(0.010045960887181016, Periodic(1))
+julia> convert(Periodic(1), r)
+Periodic(0.010045960887181016, 1)
 
-julia> convert(Continuous(),r)
-Rate(0.009995835646701251, Continuous())
+julia> convert(Continuous(), r)
+Continuous(0.009995835646701251)
 ```
 """
 function Base.convert(cf::T, r::Rate{<:Any, <:Frequency}) where {T <: Frequency}
@@ -286,18 +292,26 @@ function compounding(r::Rate{<:Any, <:Frequency})
     return r.compounding
 end
 
-function Base.isapprox(a::Rate{N, T}, b::Rate{N, T}; atol::Real = 0, rtol::Real = atol > 0 ? 0 : √eps()) where {T <: Periodic, N}
-    c = convert(a.compounding, b)
-    return (a.compounding.frequency == c.compounding.frequency) && isapprox(rate(a), rate(c); atol, rtol)
+# Note: separate methods for each Periodic/Continuous combination, with independent
+# numeric parameters N1/N2, for the same invalidation reasons as `<`/`>` below.
+# A `T <: Rate` fallback that recursed after converting compounding could never
+# align differing numeric types (e.g. Float32 vs Float64, or Dual vs Float64)
+# and would overflow the stack. Tolerance kwargs are forwarded to the scalar
+# `isapprox` so that Base's `rtoldefault` can account for mixed precisions.
+function Base.isapprox(a::Rate{N1, Periodic}, b::Rate{N2, Periodic}; kwargs...) where {N1, N2}
+    return isapprox(rate(a), rate(convert(a.compounding, b)); kwargs...)
 end
 
-function Base.isapprox(a::Rate{N, T}, b::Rate{N, T}; atol::Real = 0, rtol::Real = atol > 0 ? 0 : √eps()) where {T <: Continuous, N}
-    return isapprox(rate(a), rate(b); atol, rtol)
+function Base.isapprox(a::Rate{N1, Continuous}, b::Rate{N2, Continuous}; kwargs...) where {N1, N2}
+    return isapprox(rate(a), rate(b); kwargs...)
 end
 
-# the fallback for rates not of the same type
-function Base.isapprox(a::T, b::N; atol::Real = 0, rtol::Real = atol > 0 ? 0 : √eps()) where {T <: Rate, N <: Rate}
-    return isapprox(convert(b.compounding, a), b; atol, rtol)
+function Base.isapprox(a::Rate{N1, Periodic}, b::Rate{N2, Continuous}; kwargs...) where {N1, N2}
+    return isapprox(rate(a), rate(convert(a.compounding, b)); kwargs...)
+end
+
+function Base.isapprox(a::Rate{N1, Continuous}, b::Rate{N2, Periodic}; kwargs...) where {N1, N2}
+    return isapprox(rate(a), rate(convert(a.compounding, b)); kwargs...)
 end
 
 
@@ -358,20 +372,20 @@ forward(rate::T, to) where {T <: Rate} = rate
 forward(rate::T, from, to) where {T <: Rate} = rate
 
 """
-    +(Yields.Rate, T<:Real)
-    +(T<:Real, Yields.Rate)
-    +(Yields.Rate,Yields.Rate)
+    +(Rate, T<:Real)
+    +(T<:Real, Rate)
+    +(Rate, Rate)
 
 The addition of a rate with a number will inherit the type of the `Rate`, or the first argument's type if both are `Rate`s.
 
 # Examples
 
 ```julia-repl
-julia> Yields.Periodic(0.01,2) + Yields.Periodic(0.04,2)
-Yields.Rate{Float64, Yields.Periodic}(0.05000000000000004, Yields.Periodic(2))
+julia> Periodic(0.01, 2) + Periodic(0.04, 2)
+Periodic(0.04999999999999982, 2)
 
-julia> Yields.Periodic(0.04,2) + 0.01
-Yields.Rate{Float64, Yields.Periodic}(0.05, Yields.Periodic(2))
+julia> Periodic(0.04, 2) + 0.01
+Periodic(0.04999999999999982, 2)
 ```
 """
 function Base.:+(a::Rate{N, T}, b::Real) where {N, T <: Continuous}
@@ -396,22 +410,20 @@ function Base.:+(a::T, b::U) where {T <: Rate, U <: Rate}
 end
 
 """
-    -(Yields.Rate, T<:Real)
-    -(T<:Real, Yields.Rate)
-    -(Yields.Rate, Yields.Rate)
+    -(Rate, T<:Real)
+    -(T<:Real, Rate)
+    -(Rate, Rate)
 
-
-The addition of a rate with a number will inherit the type of the `Rate`, or the first argument's type if both are `Rate`s.
+The subtraction of a rate with a number will inherit the type of the `Rate`, or the first argument's type if both are `Rate`s.
 
 # Examples
 
 ```julia-repl
-julia> Yields.Periodic(0.04,2) - Yields.Periodic(0.01,2)
-Yields.Rate{Float64, Yields.Periodic}(0.030000000000000214, Yields.Periodic(2))
+julia> Periodic(0.04, 2) - Periodic(0.01, 2)
+Periodic(0.03000000000000025, 2)
 
-julia> Yields.Periodic(0.04,2) - 0.01
-Yields.Rate{Float64, Yields.Periodic}(0.03, Yields.Periodic(2))
-
+julia> Periodic(0.04, 2) - 0.01
+Periodic(0.03000000000000025, 2)
 ```
 """
 function Base.:-(a::Rate{N, T}, b::Real) where {N, T <: Continuous}
@@ -435,8 +447,8 @@ function Base.:-(a::T, b::U) where {T <: Rate, U <: Rate}
 end
 
 """
-    *(Yields.Rate, T)
-    *(T, Yields.Rate)
+    *(Rate, T<:Real)
+    *(T<:Real, Rate)
 
 The multiplication of a Rate with a scalar will inherit the type of the `Rate`, or the first argument's type if both are `Rate`s.
 """
@@ -456,7 +468,7 @@ end
 
 
 """
-    /(x::Yields.Rate, y::Real)
+    /(x::Rate, y::Real)
 
 The division of a Rate with a scalar will inherit the type of the `Rate`, or the first argument's type if both are `Rate`s.
 """
@@ -487,7 +499,7 @@ Convert the second argument to the periodicity of the first and compare the scal
 # Examples
 
 ```julia-repl
-julia> Yields.Periodic(0.03,100) < Yields.Continuous(0.03)
+julia> Periodic(0.03, 100) < Continuous(0.03)
 true
 ```
 """
@@ -520,7 +532,7 @@ Convert the second argument to the periodicity of the first and compare the scal
 # Examples
 
 ```julia-repl
-julia> Yields.Periodic(0.03,100) > Yields.Continuous(0.03)
+julia> Periodic(0.03, 100) > Continuous(0.03)
 false
 ```
 """

--- a/src/irr.jl
+++ b/src/irr.jl
@@ -3,16 +3,19 @@
     internal_rate_of_return(cashflows::AbstractVector, timepoints)::Rate
     internal_rate_of_return(cashflows::Vector{<:Cashflow})::Rate
 
-Calculate the internal rate of return with given timepoints. If no timepoints given, assumes equally spaced cashflows starting at time zero (0, 1, 2, ..., n).
+Calculate the internal rate of return with given timepoints. If no timepoints given, assumes equally spaced cashflows starting at time zero (`0, 1, 2, ..., n-1`). Note this differs from [`present_value`](@ref), whose default timepoints are the vector's indices (`1, 2, ..., n`).
 
-Returns a `Periodic(rate, 1)` `Rate`, or `nothing` if no root is found. Get the scalar rate by calling `rate()` on the result.
+Returns a `Periodic(rate, 1)` `Rate`. When no root can be found (e.g. degenerate or all-zero cashflows), returns `Periodic(NaN, 1)`; check with `isnan(rate(result))`. Get the scalar rate by calling `rate()` on the result.
+
+!!! note "Changed in v3.0.0"
+    Prior to v3, `nothing` was returned when no root was found. Replace `isnothing(irr(cfs))` checks with `isnan(rate(irr(cfs)))`.
 
 # Example
 ```julia-repl
 julia> internal_rate_of_return([-100,110],[0,1]) # e.g. cashflows at time 0 and 1
-Periodic(0.1, 1)
+Periodic(0.09999999999999987, 1)
 julia> internal_rate_of_return([-100,110]) # implied the same as above
-Periodic(0.1, 1)
+Periodic(0.09999999999999987, 1)
 ```
 
 # Solver notes
@@ -54,15 +57,14 @@ function irr_robust(cashflows, times)
     # IRR is scale-invariant; normalizing keeps f(r) in O(1) range
     # so that find_zeros can reliably distinguish roots from noise.
     M = maximum(abs, cashflows)
-    iszero(M) && return nothing
+    iszero(M) && return Periodic(NaN, 1)
     normalized = cashflows ./ M
     f(r) = sum(cf * exp(-r * t) for (cf, t) in zip(normalized, times))
     # operate in continuous rate space to avoid the singularity at i = -1
     # in periodic space (where (1+i)^t is undefined for fractional t)
     roots = Roots.find_zeros(f, -5.0, 3.0)
 
-    # short circuit and return nothing if no roots found
-    isempty(roots) && return nothing
+    isempty(roots) && return Periodic(NaN, 1)
     # find the root nearest zero and convert back to periodic rate
     min_i = argmin(abs.(roots))
     return Periodic(exp(roots[min_i]) - 1, 1)
@@ -71,12 +73,11 @@ end
 
 function irr_robust(cashflows::Vector{C}) where {C <: Cashflow}
     M = maximum(cf -> abs(amount(cf)), cashflows)
-    iszero(M) && return nothing
+    iszero(M) && return Periodic(NaN, 1)
     f(r) = sum(amount(cf) / M * exp(-r * timepoint(cf)) for cf in cashflows)
     roots = Roots.find_zeros(f, -5.0, 3.0)
 
-    # short circuit and return nothing if no roots found
-    isempty(roots) && return nothing
+    isempty(roots) && return Periodic(NaN, 1)
     # find the root nearest zero and convert back to periodic rate
     min_i = argmin(abs.(roots))
     return Periodic(exp(roots[min_i]) - 1, 1)
@@ -115,16 +116,13 @@ abstract type VectorizationBackend end
 struct SimdBackend <: VectorizationBackend end
 struct TurboBackend <: VectorizationBackend end
 
-# Global backend setting - extensions can change this
-const VECTORIZATION_BACKEND = Ref{VectorizationBackend}(SimdBackend())
+# Typed as a small Union so reads union-split rather than dispatching dynamically
+# on the abstract supertype. Extensions mutate the Ref in their __init__.
+const VECTORIZATION_BACKEND = Ref{Union{SimdBackend, TurboBackend}}(SimdBackend())
 
 # an internal function which calculates the
 # present value and it's derivative in one pass
 # for use in newton's method
-#
-# Dispatches to the appropriate backend. When LoopVectorization
-# is loaded, the extension sets VECTORIZATION_BACKEND to TurboBackend()
-# and provides a faster @turbo-based implementation.
 function __pv_div_pv′(r, cashflows, times)
     return __pv_div_pv′(VECTORIZATION_BACKEND[], r, cashflows, times)
 end
@@ -171,11 +169,12 @@ const irr = internal_rate_of_return
 # modified from
 # Algorithms for Optimization, Mykel J. Kochenderfer and Tim A. Wheeler, pg 88
 function __newtons_method1D_irr(cashflows, times, x, ε, k_max)
+    # read the backend Ref once per solve rather than once per iteration
+    backend = VECTORIZATION_BACKEND[]
     k = 1
     Δ = Inf
     while abs(Δ) > ε && k ≤ k_max
-        # @show x,H(x),  ∇f(x)
-        Δ = __pv_div_pv′(x, cashflows, times)
+        Δ = __pv_div_pv′(backend, x, cashflows, times)
         x -= Δ
         k += 1
     end
@@ -183,11 +182,11 @@ function __newtons_method1D_irr(cashflows, times, x, ε, k_max)
 end
 
 function __newtons_method1D_irr(cashflows::Vector{C}, x, ε, k_max) where {C <: Cashflow}
+    backend = VECTORIZATION_BACKEND[]
     k = 1
     Δ = Inf
     while abs(Δ) > ε && k ≤ k_max
-        # @show x,H(x),  ∇f(x)
-        Δ = __pv_div_pv′(x, cashflows)
+        Δ = __pv_div_pv′(backend, x, cashflows)
         x -= Δ
         k += 1
     end

--- a/src/pv.jl
+++ b/src/pv.jl
@@ -6,6 +6,9 @@ at the times specified in `timepoints`. If no `timepoints` given, assumes that c
 
 If your timepoints are dates, you can convert them into a floating point representation of the time interval using DayCounts.jl.
 
+!!! warning "Default timepoints differ from `internal_rate_of_return`"
+    With no `timepoints` argument, `present_value` assumes cashflows occur at the vector's *indices* (`1, 2, ..., n`), while [`internal_rate_of_return`](@ref) assumes they start at time zero (`0, 1, ..., n-1`). Pass explicit timepoints to avoid ambiguity.
+
 # Examples
 ```julia-repl
 julia> present_value(0.1, [10,20],[0,1])

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 DayCounts = "44e31299-2c53-5a9b-9141-82aa45d7972f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/test/Rates.jl
+++ b/test/Rates.jl
@@ -113,6 +113,29 @@
 
     end
 
+    @testset "mixed numeric type isapprox" begin
+        # mixed numeric types previously recursed to a StackOverflowError
+        @test Periodic(0.5f0, 2) ≈ Periodic(0.5, 2)
+        @test Periodic(0.5, 2) ≈ Periodic(0.5f0, 2)
+        @test Continuous(0.25f0) ≈ Continuous(0.25)
+        @test Continuous(big"0.03") ≈ Continuous(0.03)
+        @test Periodic(big"0.05", 2) ≈ Periodic(0.05, 2)
+        # mixed numeric type and mixed compounding together
+        @test convert(Continuous(), Periodic(0.5, 2)) ≈ Periodic(0.5f0, 2)
+        @test Periodic(0.5f0, 2) ≈ convert(Continuous(), Periodic(0.5, 2))
+        # still distinguishes genuinely different rates
+        @test !(Periodic(0.05f0, 2) ≈ Periodic(0.06, 2))
+        @test !(Continuous(0.03f0) ≈ Continuous(0.04))
+    end
+
+    @testset "Periodic frequency validation" begin
+        # frequency 0 used to silently produce NaN rates (0 * log(Inf))
+        @test_throws ArgumentError Periodic(0)
+        @test_throws ArgumentError Periodic(-2)
+        @test_throws ArgumentError Periodic(0.05, 0)
+        @test_throws ArgumentError Periodic(0.05, -1)
+    end
+
     @testset "discounting and accumulation" for t in [-1.3, 2.46, 6.7]
 
         unspecified_rate = 0.035

--- a/test/contracts.jl
+++ b/test/contracts.jl
@@ -34,9 +34,23 @@
     end
 
     @testset "Composite" begin
-        #TODO
-        cp = Composite(cf11, cf11)
-        @test maturity(cp) == 1
+        cp = Composite(cf11, Cashflow(2, 3))
+        @test maturity(cp) == 3
+        @test maturity(Composite(cp, Cashflow(1, 5))) == 5
+        @test cp.a == cf11
+        @test cp.b == Cashflow(2, 3)
+    end
+
+    @testset "Date-typed Cashflow" begin
+        d = Date(2026, 6, 30)
+        cf = Cashflow(100.0, d)
+        @test amount(cf) == 100.0
+        @test timepoint(cf) == d
+        @test maturity(cf) == d
+        @test -cf == Cashflow(-100.0, d)
+        @test cf * 2 == Cashflow(200.0, d)
+        @test cf + Cashflow(50.0, d) == Cashflow(150.0, d)
+        @test_throws ArgumentError cf + Cashflow(1.0, Date(2027, 6, 30))
     end
 
 end

--- a/test/irr.jl
+++ b/test/irr.jl
@@ -26,16 +26,16 @@ p(rate) = Periodic(rate, 1)
 
 
     @test irr([-100, 100]) ≈ p(0.0)
-    @test isnothing(irr([100, 100])) # answer is -1, but search range won't find it
+    @test isnan(rate(irr([100, 100]))) # answer is -1, but search range won't find it
 
     # test the unsolvable
-    @test isnothing(irr([-1.0e8, 0.0, 0.0, 0.0], 0:3))
+    @test isnan(rate(irr([-1.0e8, 0.0, 0.0, 0.0], 0:3)))
 
-    # all-zero or near-zero cashflows should return nothing, not throw
-    @test isnothing(irr([0.0, 0.0, 0.0]))
-    @test isnothing(irr([0.0, 0.0, 0.0], 0:2))
-    @test isnothing(irr([1.0e-50, 1.0e-50, 1.0e-50]))
-    @test isnothing(irr([1.0e-300, 1.0e-300, 1.0e-300], 0:2))
+    # all-zero or near-zero cashflows should return NaN rate, not throw
+    @test isnan(rate(irr([0.0, 0.0, 0.0])))
+    @test isnan(rate(irr([0.0, 0.0, 0.0], 0:2)))
+    @test isnan(rate(irr([1.0e-50, 1.0e-50, 1.0e-50])))
+    @test isnan(rate(irr([1.0e-300, 1.0e-300, 1.0e-300], 0:2)))
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,6 @@ using LoopVectorization
     @test FinanceCore.VECTORIZATION_BACKEND[] isa FinanceCore.TurboBackend
     @test irr([-100, 110]) ≈ Periodic(0.1, 1)
     @test irr([-100, 110], [0, 1]) ≈ Periodic(0.1, 1)
-    @test isnan(rate(irr([0.0, 0.0, 0.0])))
+    @test isnothing(irr([0.0, 0.0, 0.0]))
     @test irr([Cashflow(-100.0, 0.0), Cashflow(110.0, 1.0)]) ≈ Periodic(0.1, 1)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,6 @@ using LoopVectorization
     @test FinanceCore.VECTORIZATION_BACKEND[] isa FinanceCore.TurboBackend
     @test irr([-100, 110]) ≈ Periodic(0.1, 1)
     @test irr([-100, 110], [0, 1]) ≈ Periodic(0.1, 1)
-    @test isnothing(irr([0.0, 0.0, 0.0]))
+    @test isnan(rate(irr([0.0, 0.0, 0.0])))
     @test irr([Cashflow(-100.0, 0.0), Cashflow(110.0, 1.0)]) ≈ Periodic(0.1, 1)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,3 +13,14 @@ using Aqua
 @testset "Aqua.jl" begin
     Aqua.test_all(FinanceCore; ambiguities = false)
 end
+
+# Load LoopVectorization last: its extension flips VECTORIZATION_BACKEND for the
+# remainder of the session, so these exercise the @turbo irr kernels.
+using LoopVectorization
+@testset "LoopVectorization extension" begin
+    @test FinanceCore.VECTORIZATION_BACKEND[] isa FinanceCore.TurboBackend
+    @test irr([-100, 110]) ≈ Periodic(0.1, 1)
+    @test irr([-100, 110], [0, 1]) ≈ Periodic(0.1, 1)
+    @test isnan(rate(irr([0.0, 0.0, 0.0])))
+    @test irr([Cashflow(-100.0, 0.0), Cashflow(110.0, 1.0)]) ≈ Periodic(0.1, 1)
+end


### PR DESCRIPTION
**Breaking (v3.0.0), standing on its own for the design decision.** Stacked on #42 (`release/2.5.4`); base is that branch so this PR shows only the single `irr` commit. Retargets to `main` when 2.5.4 lands.

`irr` / `internal_rate_of_return` return **`Periodic(NaN, 1)` instead of `nothing`** when no root is found, so the return type is always a `Rate`. Migration: replace `isnothing(irr(x))` with `isnan(rate(irr(x)))`.

### Relationship to the other open irr PRs
This is an **alternative direction** to #38 ("Bulletproof irr *nothing* contract") — that PR invests in the `nothing` return; this one replaces it with NaN. It also overlaps #37 (irr internals refactor). Pick one direction; they shouldn't all merge.

### Honest assessment (so the decision is informed)
- **No measurable performance benefit.** A benchmark isolating *only* the return-type contract (real v3 kernel, 10k-stream "compute IRRs once, sweep analytics many times" workload) shows the `Union{Nothing,Rate}` and `Rate` paths within noise, 0 allocations both — `Union{Nothing, isbits-Rate}` is the case Julia's union-splitting handles essentially for free.
- **The real win is composability/contract honesty.** `discount(irr(cfs), t)` on a no-root stream **returns `NaN` (propagates)** under this change but **throws `MethodError: discount(::Nothing, …)`** today. NaN is also unmistakable as a non-answer (`isnan(rate(r))`), and the result type is concrete.
- **Nothing downstream requires it.** FinanceModels/ActuaryUtilities/EconomicScenarioGenerators have no source consuming the `nothing` contract; their compat already admits FC 3 but resolves fine against 2.5.x. So this can ship (or not) on its own timeline.

Caveat worth weighing: it breaks **silently** — `isnothing(irr(x))` checks don't error, they just take the wrong branch with a NaN rate. A `MethodError` would be louder. Consider pairing with an `issolved(::Rate)`/`isfailed` helper for a discoverable check.

Full suite passes under the NaN contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
