### PR TITLE
Enable Aqua ambiguity check (FinanceCore is ambiguity-clean)

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,7 +11,7 @@ include("contracts.jl")
 
 using Aqua
 @testset "Aqua.jl" begin
-    Aqua.test_all(FinanceCore; ambiguities = false)
+    Aqua.test_all(FinanceCore)
 end
 
 # Load LoopVectorization last: its extension flips VECTORIZATION_BACKEND for the


### PR DESCRIPTION
Small test hardening: enable Aqua's ambiguity check for FinanceCore (it was previously skipped with `ambiguities = false`).

`detect_ambiguities(FinanceCore; recursive=true) == 0`, so the check passes as-is — this just locks it in so a future ambiguity is caught in CI. Full suite green (Aqua 11/11).

Standalone off `main` (independent of the v3.0.0 `irr` proposal in #43) so it lands regardless of that decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
