### PR TITLE
Use log1p/expm1 for nominal↔continuous rate conversion precision (v2.5.5)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FinanceCore"
 uuid = "b9b1ffdd-6612-4b69-8227-7663be06e089"
-version = "2.5.4"
+version = "2.5.5"
 authors = ["alecloudenback <alecloudenback@users.noreply.github.com> and contributors"]
 
 [deps]

--- a/src/Rates.jl
+++ b/src/Rates.jl
@@ -108,8 +108,11 @@ end
 
 # Outer constructor for Periodic rates - precompute continuous equivalent
 function Rate(value::N, compounding::Periodic) where {N}
-    # continuous_value = n * log(1 + r/n), which is the equivalent continuous rate
-    continuous_value = compounding.frequency * log(1 + value / compounding.frequency)
+    # continuous_value = n * log(1 + r/n), which is the equivalent continuous rate.
+    # log1p (and expm1 on the way back in `rate`) keeps the nominal↔continuous
+    # round-trip accurate to ~1 ulp for small r/n, where log(1 + x) alone loses
+    # ~x⁻¹·eps of relative precision.
+    continuous_value = compounding.frequency * log1p(value / compounding.frequency)
     return Rate{N, Periodic}(convert(N, continuous_value), compounding)
 end
 
@@ -187,13 +190,13 @@ Returns a `Rate` with an equivalent discount but represented with a different co
 
 ```julia-repl
 julia> r = Rate(0.01, Periodic(12))
-Periodic(0.009999999999998899, 12)
+Periodic(0.009999999999999998, 12)
 
 julia> convert(Periodic(1), r)
-Periodic(0.010045960887181016, 1)
+Periodic(0.010045960887182024, 1)
 
 julia> convert(Continuous(), r)
-Continuous(0.009995835646701251)
+Continuous(0.009995835646702353)
 ```
 """
 function Base.convert(cf::T, r::Rate{<:Any, <:Frequency}) where {T <: Frequency}
@@ -210,7 +213,7 @@ end
 
 function Base.convert(to::Periodic, r, from::Continuous)
     # For Continuous rates, continuous_value equals the rate value
-    return Rate.(to.frequency * (exp(r.continuous_value / to.frequency) - 1), to)
+    return Rate.(to.frequency * expm1(r.continuous_value / to.frequency), to)
 end
 
 function Base.convert(to::Continuous, r, from::Periodic)
@@ -220,7 +223,7 @@ end
 
 function Base.convert(to::Periodic, r, from::Periodic)
     # r.continuous_value is the equivalent continuous rate, use it to convert directly
-    return Rate.(to.frequency * (exp(r.continuous_value / to.frequency) - 1), to)
+    return Rate.(to.frequency * expm1(r.continuous_value / to.frequency), to)
 end
 
 function Continuous(r::Rate{<:Any, <:Periodic})
@@ -262,9 +265,10 @@ function rate(r::Rate{<:Any, Continuous})
 end
 
 function rate(r::Rate{<:Any, Periodic})
-    # continuous_value = n * log(1 + r/n), so r = n * (exp(continuous_value/n) - 1)
+    # continuous_value = n * log1p(r/n), so r = n * expm1(continuous_value/n).
+    # expm1 mirrors the constructor's log1p so the round-trip is ~1 ulp accurate.
     n = r.compounding.frequency
-    return n * (exp(r.continuous_value / n) - 1)
+    return n * expm1(r.continuous_value / n)
 end
 
 """
@@ -382,10 +386,10 @@ The addition of a rate with a number will inherit the type of the `Rate`, or the
 
 ```julia-repl
 julia> Periodic(0.01, 2) + Periodic(0.04, 2)
-Periodic(0.04999999999999982, 2)
+Periodic(0.05, 2)
 
 julia> Periodic(0.04, 2) + 0.01
-Periodic(0.04999999999999982, 2)
+Periodic(0.05, 2)
 ```
 """
 function Base.:+(a::Rate{N, T}, b::Real) where {N, T <: Continuous}
@@ -420,10 +424,10 @@ The subtraction of a rate with a number will inherit the type of the `Rate`, or 
 
 ```julia-repl
 julia> Periodic(0.04, 2) - Periodic(0.01, 2)
-Periodic(0.03000000000000025, 2)
+Periodic(0.03, 2)
 
 julia> Periodic(0.04, 2) - 0.01
-Periodic(0.03000000000000025, 2)
+Periodic(0.03, 2)
 ```
 """
 function Base.:-(a::Rate{N, T}, b::Real) where {N, T <: Continuous}

--- a/test/Rates.jl
+++ b/test/Rates.jl
@@ -62,6 +62,24 @@
         @test rate(c2) == 0.06
     end
 
+    @testset "nominal↔continuous round-trip precision" begin
+        # The constructor stores n*log1p(r/n) and rate() inverts with n*expm1(cv/n),
+        # so the nominal rate survives a construction round-trip to within a few ulps
+        # even when r/n is small (log(1+x) alone loses ~x⁻¹·eps of relative precision).
+        for f in (1, 2, 4, 12, 365), r in (1.0e-6, 1.0e-4, 0.01, 0.05, 0.5, -0.01, -0.2)
+            @test rate(Periodic(r, f)) ≈ r rtol = 4 * eps()
+        end
+
+        # arithmetic in nominal space no longer accretes conversion noise
+        @test rate(Periodic(0.01, 2) + Periodic(0.04, 2)) ≈ 0.05 rtol = 4 * eps()
+        @test rate(Periodic(0.04, 2) - Periodic(0.01, 2)) ≈ 0.03 rtol = 4 * eps()
+
+        # Float32 values stay Float32 and round-trip at Float32 precision
+        r32 = Periodic(0.01f0, 12)
+        @test rate(r32) isa Float32
+        @test rate(r32) ≈ 0.01f0 rtol = 4 * eps(Float32)
+    end
+
     @testset "compounding() function returns compounding frequency" begin
         # Test compounding() returns Continuous() for continuous rates
         c = Rate(0.05, Continuous())


### PR DESCRIPTION
## Summary

The `Periodic` outer constructor computes the stored continuous-equivalent rate as `n * log(1 + r/n)`, and `rate()` inverts it with `n * (exp(cv/n) - 1)`. For small `r/n` both steps lose precision (relative error ~`eps/x`), which showed up directly in user-facing output:

- `rate(Periodic(0.01, 12))` → `0.009999999999998899` (error ~1e-15)
- `Periodic(0.01, 2) + Periodic(0.04, 2)` → `Periodic(0.04999999999999982, 2)`

This PR switches the conversion to `log1p`/`expm1` in four places: the `Rate(value, ::Periodic)` constructor, `rate(::Rate{<:Any, Periodic})`, and the two `convert(::Periodic, ...)` methods. The nominal↔continuous round-trip error drops from ~1e-15 to ~1 ulp (~2e-18 at r=0.01):

- `rate(Periodic(0.01, 12))` → `0.009999999999999998`
- `Periodic(0.01, 2) + Periodic(0.04, 2)` → `Periodic(0.05, 2)`

Both functions have DiffRules definitions, so ForwardDiff/AD paths are unaffected.

## Changes

- `src/Rates.jl`: `log1p`/`expm1` in constructor, `rate()`, and `convert` methods; docstring examples updated to the new (cleaner) outputs
- `test/Rates.jl`: round-trip precision testset (grid of rates × frequencies at `rtol = 4eps()`, arithmetic noise checks, Float32 preservation)
- `Project.toml`: 2.5.4 → 2.5.5 (adjust if another PR merges first)

## Notes

- Domain behavior is unchanged: `log1p` has the same `r/n > -1` domain as `log(1 + r/n)`.
- Overlaps trivially with #45 (which touches the same lines on its branch); whichever merges second needs a mechanical rebase.

## Test plan

- [x] Full test suite passes locally (153 Rates tests + irr/pv/cashflows/Aqua/LoopVectorization ext)

🤖 Generated with [Claude Code](https://claude.com/claude-code)