### PR TITLE
Define ==/isequal/hash for Rate as force-of-interest equality (v2.6.0)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FinanceCore"
 uuid = "b9b1ffdd-6612-4b69-8227-7663be06e089"
-version = "2.5.4"
+version = "2.6.0"
 authors = ["alecloudenback <alecloudenback@users.noreply.github.com> and contributors"]
 
 [deps]

--- a/src/Rates.jl
+++ b/src/Rates.jl
@@ -314,6 +314,57 @@ function Base.isapprox(a::Rate{N1, Continuous}, b::Rate{N2, Periodic}; kwargs...
     return isapprox(rate(a), rate(convert(a.compounding, b)); kwargs...)
 end
 
+"""
+    ==(a::Rate, b::Rate)
+
+Two `Rate`s are equal when they represent the same force of interest — the same
+continuously compounded equivalent rate — regardless of the compounding convention
+they are quoted in. This makes `==` consistent with the orderings defined by `<`,
+`>`, and with `isapprox`, all of which compare across compounding conventions.
+
+Note that equality is exact on the underlying floating-point representation:
+rates that are economically equal but arrive at their internal continuous value
+through different rounding will *not* compare `==` (use `isapprox` for that),
+while a `Rate` and its `convert`ed representation in another compounding
+convention (which shares the internal value exactly) will.
+
+# Examples
+
+```julia-repl
+julia> r = Periodic(0.05, 2);
+
+julia> r == convert(Continuous(), r)
+true
+
+julia> r == Periodic(0.05, 2)
+true
+
+julia> Periodic(0.05, 2) == Periodic(0.05, 4)
+false
+```
+"""
+# Equality, isequal, and hash all reduce to the stored `continuous_value`, keeping the
+# `isequal`/`hash` contract (equal values hash equally, including across
+# Periodic/Continuous). `isequal` forwards to `isequal` on the underlying numbers so
+# NaN/-0.0 semantics match Base's.
+#
+# Note: separate concrete Periodic/Continuous combinations, matching the
+# invalidation-avoidance convention of `isapprox` above and `<`/`>` below.
+Base.:(==)(a::Rate{N1, Periodic}, b::Rate{N2, Periodic}) where {N1, N2} = a.continuous_value == b.continuous_value
+Base.:(==)(a::Rate{N1, Continuous}, b::Rate{N2, Continuous}) where {N1, N2} = a.continuous_value == b.continuous_value
+Base.:(==)(a::Rate{N1, Periodic}, b::Rate{N2, Continuous}) where {N1, N2} = a.continuous_value == b.continuous_value
+Base.:(==)(a::Rate{N1, Continuous}, b::Rate{N2, Periodic}) where {N1, N2} = a.continuous_value == b.continuous_value
+
+Base.isequal(a::Rate{N1, Periodic}, b::Rate{N2, Periodic}) where {N1, N2} = isequal(a.continuous_value, b.continuous_value)
+Base.isequal(a::Rate{N1, Continuous}, b::Rate{N2, Continuous}) where {N1, N2} = isequal(a.continuous_value, b.continuous_value)
+Base.isequal(a::Rate{N1, Periodic}, b::Rate{N2, Continuous}) where {N1, N2} = isequal(a.continuous_value, b.continuous_value)
+Base.isequal(a::Rate{N1, Continuous}, b::Rate{N2, Periodic}) where {N1, N2} = isequal(a.continuous_value, b.continuous_value)
+
+# The compounding convention is deliberately excluded from the hash: equal-force rates
+# are `==`/`isequal` across conventions, so they must hash identically.
+Base.hash(r::Rate{<:Any, Periodic}, h::UInt) = hash(r.continuous_value, hash(:FinanceCoreRate, h))
+Base.hash(r::Rate{<:Any, Continuous}, h::UInt) = hash(r.continuous_value, hash(:FinanceCoreRate, h))
+
 
 """
     discount(rate, t)

--- a/test/Rates.jl
+++ b/test/Rates.jl
@@ -113,6 +113,44 @@
 
     end
 
+    @testset "force-of-interest equality and hashing" begin
+        p = Periodic(0.05, 2)
+        c = convert(Continuous(), p)   # shares the internal continuous value exactly
+
+        # == is force equality, consistent with <, >, and isapprox semantics
+        @test p == c
+        @test c == p
+        @test isequal(p, c)
+        @test hash(p) == hash(c)
+        @test !(p < c) && !(p > c)   # equal force: neither ordering holds
+
+        # same nominal rate, different frequency → different force
+        @test Periodic(0.05, 2) != Periodic(0.05, 4)
+        @test Continuous(0.03) != Continuous(0.04)
+
+        # equality stays exact: economically equal but differently-rounded rates
+        # are only ≈, never ==
+        a = Periodic(0.02, 2)
+        a_eq = Periodic((1 + 0.02 / 2)^2 - 1, 1)
+        @test a != a_eq
+        @test a ≈ a_eq
+
+        # Dict/Set follow isequal/hash across compounding conventions
+        @test length(Set([p, c])) == 1
+        d = Dict(p => 1)
+        @test d[c] == 1
+
+        # mixed numeric types with exactly representable values
+        @test Continuous(0.5) == Continuous(0.5f0)
+
+        # NaN follows Base number semantics: == is false, isequal/hash agree
+        n1 = Continuous(NaN)
+        n2 = Continuous(NaN)
+        @test n1 != n2
+        @test isequal(n1, n2)
+        @test hash(n1) == hash(n2)
+    end
+
     @testset "mixed numeric type isapprox" begin
         # mixed numeric types previously recursed to a StackOverflowError
         @test Periodic(0.5f0, 2) ≈ Periodic(0.5, 2)


### PR DESCRIPTION
## Summary

`<`, `>`, and `isapprox` all compare `Rate`s across compounding conventions — they order by force of interest. But `==` fell back to default struct equality, so for a `Periodic` rate `p` and its exactly-equivalent `Continuous` representation `c = convert(Continuous(), p)`:

```julia
p < c   # false
p > c   # false
p == c  # false  ← broken total order
p ≈ c   # true
```

This PR makes `==`, `isequal`, and `hash` all reduce to the stored `continuous_value`:

- **`==` is exact force equality.** Rates that are economically equal but arrive at their internal value through different rounding still compare unequal (use `isapprox`) — the existing test `Periodic(0.02, 2) != Periodic((1 + 0.02/2)^2 - 1, 1)` is unchanged.
- **`isequal`** forwards to `isequal` on the underlying numbers, so NaN and `-0.0` follow Base's number semantics and the `isequal`/`hash` contract holds.
- **`hash`** excludes the compounding convention (it must, since equal-force rates are `isequal` across conventions), so `Dict`/`Set` treat `p` and `c` as the same key.

Concrete Periodic/Continuous method combinations throughout, per the repo's invalidation-avoidance convention.

## Semantic note (maintainer decision)

This changes observable behavior: `Periodic(x, 2) == Continuous(equivalent)` was `false`, now `true` — and two `Periodic` rates with different frequencies whose forces coincide exactly are now equal. I've versioned this as a minor bump (2.5.4 → 2.6.0) on the argument that the previous `==` was an accidental struct-equality fallback, but if you consider `==` semantics part of the public contract, this is the one PR in this series that arguably warrants 3.0.

## Changes

- `src/Rates.jl`: `==`/`isequal` (4 concrete combos each), `hash` (2 methods), docstring
- `test/Rates.jl`: force-equality testset (cross-convention equality, ordering consistency, exactness, Set/Dict behavior, mixed numeric types, NaN)
- `Project.toml`: 2.5.4 → 2.6.0 (adjust per merge order)

## Test plan

- [x] Full test suite passes locally (129 Rates tests incl. new testset; all pre-existing equality tests unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)