### PR TITLE
Fix InexactError constructing Periodic Rates from integer values (v2.6.0)

### DIFF
--- a/src/Rates.jl
+++ b/src/Rates.jl
@@ -107,13 +107,17 @@ function Rate(value::N, compounding::Continuous) where {N}
 end
 
 # Outer constructor for Periodic rates - precompute continuous equivalent
-function Rate(value::N, compounding::Periodic) where {N}
-    # continuous_value = n * log(1 + r/n), which is the equivalent continuous rate.
+function Rate(value, compounding::Periodic)
+    # continuous_value = n * log1p(r/n), which is the equivalent continuous rate.
     # log1p (and expm1 on the way back in `rate`) keeps the nominal↔continuous
     # round-trip accurate to ~1 ulp for small r/n, where log(1 + x) alone loses
     # ~x⁻¹·eps of relative precision.
+    # The numeric type parameter follows the computed continuous value (Float64 for
+    # integer input, Float32 for Float32 input, Dual for Dual input, ...) rather than
+    # converting back to the input type — converting a generally-irrational log back
+    # to e.g. an integer type is an InexactError (Rate(1, Periodic(1)) used to throw).
     continuous_value = compounding.frequency * log1p(value / compounding.frequency)
-    return Rate{N, Periodic}(convert(N, continuous_value), compounding)
+    return Rate{typeof(continuous_value), Periodic}(continuous_value, compounding)
 end
 
 # make rate a broadcastable type

--- a/test/Rates.jl
+++ b/test/Rates.jl
@@ -19,6 +19,31 @@
 
     end
 
+    @testset "integer rate values" begin
+        # Rate(1, Periodic(1)) — a 100% annual effective rate — previously threw
+        # InexactError from converting the (irrational) continuous equivalent back
+        # to the integer input type. The numeric parameter now follows the computed
+        # continuous value instead.
+        r = Rate(1, Periodic(1))
+        @test r isa Rate{Float64, Periodic}
+        @test rate(r) ≈ 1.0
+        @test accumulation(r, 1) ≈ 2.0
+        @test discount(r, 1) ≈ 0.5
+
+        @test Periodic(1, 2) isa Rate{Float64, Periodic}
+        @test Rate(2) isa Rate{Float64, Periodic}
+
+        # a zero integer rate remains constructible
+        @test rate(Rate(0, Periodic(4))) == 0.0
+
+        # non-integer numeric types keep their type
+        @test Rate(0.05f0, Periodic(2)) isa Rate{Float32, Periodic}
+        @test Rate(big"0.05", Periodic(2)) isa Rate{BigFloat, Periodic}
+
+        # integer-valued Continuous rates were already constructible; unchanged
+        @test accumulation(Rate(1, Continuous()), 1) ≈ exp(1)
+    end
+
     @testset "rate conversions" begin
         m = Rate(0.1, Periodic(2))
         @test convert(Periodic(2), 0.1) ≈ m


### PR DESCRIPTION
## Summary

`Rate(1, Periodic(1))` — a 100% annual effective rate — threw a confusing internal error:

```julia
julia> Rate(1, Periodic(1))
ERROR: InexactError: Int64(0.6931471805599453)
```

The Periodic outer constructor computed the continuous-equivalent value (generally irrational) and then `convert`ed it back to the input's numeric type `N` — impossible for integer types. `Rate(1, Continuous())` worked fine, so the two constructors were inconsistent.

## Fix

The numeric type parameter now follows the *computed continuous value* instead of the input:

```julia
continuous_value = compounding.frequency * log(1 + value / compounding.frequency)
return Rate{typeof(continuous_value), Periodic}(continuous_value, compounding)
```

- Integer input → `Rate{Float64, Periodic}` (standard numeric promotion, was an error)
- `Float32`/`Float64`/`BigFloat`/ForwardDiff `Dual` inputs → unchanged type, and the redundant `convert` disappears
- `Rate(0, Periodic(n))` changes from `Rate{Int}` to `Rate{Float64}` — the one previously-working integer case, now consistent with every other integer input

## Changes

- `src/Rates.jl`: constructor type parametrization
- `test/Rates.jl`: integer-value testset (construction, rate/discount/accumulation round-trip, type preservation for Float32/BigFloat, Continuous unchanged)
- `Project.toml`: 2.5.4 → 2.6.0 (adjust per merge order; trivially overlaps #45/#46 on the constructor lines)

## Test plan

- [x] Full test suite passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)