### PR TITLE
Add DayCounts extension: discount/accumulation over Date intervals (v2.6.0)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FinanceCore"
 uuid = "b9b1ffdd-6612-4b69-8227-7663be06e089"
-version = "2.5.4"
+version = "2.6.0"
 authors = ["alecloudenback <alecloudenback@users.noreply.github.com> and contributors"]
 
 [deps]
@@ -8,13 +8,16 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 
 [weakdeps]
+DayCounts = "44e31299-2c53-5a9b-9141-82aa45d7972f"
 LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
 
 [extensions]
+FinanceCoreDayCountsExt = "DayCounts"
 FinanceCoreLoopVectorizationExt = "LoopVectorization"
 
 [compat]
 Dates = "1"
+DayCounts = "0.1"
 LoopVectorization = "0.12"
 Roots = "1, 2"
 julia = "1.10"

--- a/ext/FinanceCoreDayCountsExt.jl
+++ b/ext/FinanceCoreDayCountsExt.jl
@@ -1,0 +1,54 @@
+module FinanceCoreDayCountsExt
+
+import FinanceCore
+import DayCounts
+import Dates
+
+"""
+    discount(rate, from::Date, to::Date, dc::DayCounts.DayCount)
+
+Discount `rate` over the interval between two `Date`s, with the interval measured as a
+year fraction under the day count convention `dc` (via `DayCounts.yearfrac(from, to, dc)`).
+As with the scalar-time methods, a non-`Rate` `rate` is assumed to be `Periodic(rate, 1)`.
+
+Available when DayCounts.jl is loaded.
+
+# Examples
+
+```julia-repl
+julia> using FinanceCore, DayCounts, Dates
+
+julia> discount(0.05, Date(2024, 1, 1), Date(2024, 7, 1), DayCounts.Actual365Fixed())
+0.9759653002306966
+
+julia> discount(0.05, DayCounts.yearfrac(Date(2024, 1, 1), Date(2024, 7, 1), DayCounts.Actual365Fixed()))
+0.9759653002306966
+```
+"""
+function FinanceCore.discount(rate, from::Dates.Date, to::Dates.Date, dc::DayCounts.DayCount)
+    return FinanceCore.discount(rate, DayCounts.yearfrac(from, to, dc))
+end
+
+"""
+    accumulation(rate, from::Date, to::Date, dc::DayCounts.DayCount)
+
+Accumulate `rate` over the interval between two `Date`s, with the interval measured as a
+year fraction under the day count convention `dc` (via `DayCounts.yearfrac(from, to, dc)`).
+As with the scalar-time methods, a non-`Rate` `rate` is assumed to be `Periodic(rate, 1)`.
+
+Available when DayCounts.jl is loaded.
+
+# Examples
+
+```julia-repl
+julia> using FinanceCore, DayCounts, Dates
+
+julia> accumulation(0.05, Date(2024, 1, 1), Date(2024, 7, 1), DayCounts.Thirty360())
+1.02469507659596
+```
+"""
+function FinanceCore.accumulation(rate, from::Dates.Date, to::Dates.Date, dc::DayCounts.DayCount)
+    return FinanceCore.accumulation(rate, DayCounts.yearfrac(from, to, dc))
+end
+
+end

--- a/src/Rates.jl
+++ b/src/Rates.jl
@@ -318,8 +318,11 @@ end
 """
     discount(rate, t)
     discount(rate, from, to)
+    discount(rate, from::Date, to::Date, dc::DayCounts.DayCount)
 
-Discount `rate` for a time `t` or for an interval `(from, to)`. If `rate` is not a `Rate`, it will be assumed to be a `Periodic` rate compounded once per period, i.e. `Periodic(rate,1)`. 
+Discount `rate` for a time `t` or for an interval `(from, to)`. If `rate` is not a `Rate`, it will be assumed to be a `Periodic` rate compounded once per period, i.e. `Periodic(rate,1)`.
+
+When [DayCounts.jl](https://github.com/JuliaFinance/DayCounts.jl) is loaded, a `Date` interval can be discounted directly by passing a day count convention, which measures the interval via `DayCounts.yearfrac(from, to, dc)`.
 
 # Examples
 
@@ -344,8 +347,11 @@ discount(rate, from, to) = discount(rate, to - from)
 """
     accumulation(rate, t)
     accumulation(rate, from, to)
+    accumulation(rate, from::Date, to::Date, dc::DayCounts.DayCount)
 
-Accumulate `rate` for a time `t` or for an interval `(from, to)`. If `rate` is not a `Rate`, it will be assumed to be a `Periodic` rate compounded once per period, i.e. `Periodic(rate,1)`. 
+Accumulate `rate` for a time `t` or for an interval `(from, to)`. If `rate` is not a `Rate`, it will be assumed to be a `Periodic` rate compounded once per period, i.e. `Periodic(rate,1)`.
+
+When [DayCounts.jl](https://github.com/JuliaFinance/DayCounts.jl) is loaded, accumulation over a `Date` interval can be computed directly by passing a day count convention, which measures the interval via `DayCounts.yearfrac(from, to, dc)`.
 
     # Examples
 

--- a/test/daycounts.jl
+++ b/test/daycounts.jl
@@ -1,0 +1,33 @@
+@testset "DayCounts extension" begin
+    d1 = Date(2024, 1, 1)
+    d2 = Date(2024, 7, 1)
+
+    conventions = (
+        DayCounts.Actual365Fixed(),
+        DayCounts.Actual360(),
+        DayCounts.Thirty360(),
+        DayCounts.ActualActualISDA(),
+    )
+
+    @testset "$(nameof(typeof(dc)))" for dc in conventions
+        t = DayCounts.yearfrac(d1, d2, dc)
+
+        # date methods agree exactly with the scalar-time methods at the
+        # convention's year fraction, for Real and both Rate types
+        @test discount(0.05, d1, d2, dc) == discount(0.05, t)
+        @test accumulation(0.05, d1, d2, dc) == accumulation(0.05, t)
+        @test discount(Continuous(0.05), d1, d2, dc) == exp(-0.05 * t)
+        @test discount(Periodic(0.05, 2), d1, d2, dc) == discount(Periodic(0.05, 2), t)
+        @test accumulation(Periodic(0.05, 2), d1, d2, dc) == accumulation(Periodic(0.05, 2), t)
+
+        # discount and accumulation invert each other
+        @test discount(Periodic(0.05, 2), d1, d2, dc) * accumulation(Periodic(0.05, 2), d1, d2, dc) ≈ 1.0
+    end
+
+    # a degenerate interval discounts to exactly 1
+    @test discount(Continuous(0.03), d1, d1, DayCounts.Actual365Fixed()) == 1.0
+
+    # reversed dates give a negative year fraction, so discount inverts
+    t = DayCounts.yearfrac(d1, d2, DayCounts.Actual365Fixed())
+    @test discount(Continuous(0.03), d2, d1, DayCounts.Actual365Fixed()) ≈ exp(0.03 * t)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ include("Rates.jl")
 include("irr.jl")
 include("present_value.jl")
 include("contracts.jl")
+include("daycounts.jl")
 
 using Aqua
 @testset "Aqua.jl" begin


### PR DESCRIPTION
## Summary

`Timepoint` and `Cashflow` accept `Dates.Date`, but the rate math couldn't consume dates: `discount(rate, Date(...), Date(...))` fails because the `Day` period can't multiply a rate, and the docstrings punted to "convert with DayCounts.jl yourself."

This PR adds a package extension, **FinanceCoreDayCountsExt** (loaded automatically when [DayCounts.jl](https://github.com/JuliaFinance/DayCounts.jl) is present), providing:

```julia
discount(rate,     from::Date, to::Date, dc::DayCounts.DayCount)
accumulation(rate, from::Date, to::Date, dc::DayCounts.DayCount)
```

with the interval measured via `DayCounts.yearfrac(from, to, dc)`. `rate` can be a `Rate` or a `Real` (assumed `Periodic(rate, 1)`, same as the scalar-time methods).

Design choice: **no default convention.** `discount(rate, from::Date, to::Date)` without a day count still errors naturally — silently assuming Actual/365 (or anything else) would be a hidden pricing convention.

## Changes

- `ext/FinanceCoreDayCountsExt.jl` (new): the two methods, with docstrings and verified examples
- `Project.toml`: DayCounts weakdep + extension + `compat DayCounts = \"0.1\"`; version 2.5.4 → 2.6.0 (adjust per merge order)
- `src/Rates.jl`: `discount`/`accumulation` docstrings note the Date methods
- `test/daycounts.jl` (new, wired into runtests): exact agreement with scalar-time methods across four conventions (Actual365Fixed, Actual360, Thirty360, ActualActualISDA) for Real/Periodic/Continuous rates, discount·accumulation inversion, degenerate and reversed intervals

DayCounts was already a test dependency (used by the xirr date tests), so no test-infrastructure changes were needed.

## Possible follow-ups (out of scope)

- `present_value` for `Cashflow{A, Date}` vectors given an as-of date + convention
- the same extension pattern in FinanceModels for yield-curve `discount(curve, from::Date, to::Date, dc)`

## Test plan

- [x] Full test suite passes locally (26 new tests; Aqua validates the extension wiring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)