### PR TITLE
Preserve tiny displayed IRRs with expm1

### DIFF
--- a/src/irr.jl
+++ b/src/irr.jl
@@ -50,6 +50,10 @@ end
 
 irr_robust(cashflows) = irr_robust(cashflows, 0:(length(cashflows) - 1))
 
+# Convert a force of interest from the solvers to an annual effective rate.
+# `expm1` preserves nominal rates too small for `exp(r) - 1` to represent.
+_periodic_from_force(r) = Periodic(expm1(r), 1)
+
 function irr_robust(cashflows, times)
     # IRR is scale-invariant; normalizing keeps f(r) in O(1) range
     # so that find_zeros can reliably distinguish roots from noise.
@@ -65,7 +69,7 @@ function irr_robust(cashflows, times)
     isempty(roots) && return nothing
     # find the root nearest zero and convert back to periodic rate
     min_i = argmin(abs.(roots))
-    return Periodic(expm1(roots[min_i]), 1)
+    return _periodic_from_force(roots[min_i])
 
 end
 
@@ -79,7 +83,7 @@ function irr_robust(cashflows::Vector{C}) where {C <: Cashflow}
     isempty(roots) && return nothing
     # find the root nearest zero and convert back to periodic rate
     min_i = argmin(abs.(roots))
-    return Periodic(expm1(roots[min_i]), 1)
+    return _periodic_from_force(roots[min_i])
 
 end
 
@@ -94,7 +98,7 @@ function irr_newton(cashflows, times)
         1.0e-9,
         100
     )
-    return Periodic(expm1(r), 1)
+    return _periodic_from_force(r)
 
 end
 
@@ -106,7 +110,7 @@ function irr_newton(cashflows::Vector{C}) where {C <: Cashflow}
         1.0e-9,
         100
     )
-    return Periodic(expm1(r), 1)
+    return _periodic_from_force(r)
 
 end
 

--- a/src/irr.jl
+++ b/src/irr.jl
@@ -65,7 +65,7 @@ function irr_robust(cashflows, times)
     isempty(roots) && return nothing
     # find the root nearest zero and convert back to periodic rate
     min_i = argmin(abs.(roots))
-    return Periodic(exp(roots[min_i]) - 1, 1)
+    return Periodic(expm1(roots[min_i]), 1)
 
 end
 
@@ -79,7 +79,7 @@ function irr_robust(cashflows::Vector{C}) where {C <: Cashflow}
     isempty(roots) && return nothing
     # find the root nearest zero and convert back to periodic rate
     min_i = argmin(abs.(roots))
-    return Periodic(exp(roots[min_i]) - 1, 1)
+    return Periodic(expm1(roots[min_i]), 1)
 
 end
 
@@ -94,7 +94,7 @@ function irr_newton(cashflows, times)
         1.0e-9,
         100
     )
-    return Periodic(exp(r) - 1, 1)
+    return Periodic(expm1(r), 1)
 
 end
 
@@ -106,7 +106,7 @@ function irr_newton(cashflows::Vector{C}) where {C <: Cashflow}
         1.0e-9,
         100
     )
-    return Periodic(exp(r) - 1, 1)
+    return Periodic(expm1(r), 1)
 
 end
 

--- a/test/Rates.jl
+++ b/test/Rates.jl
@@ -88,8 +88,6 @@
     end
 
     @testset "nominal↔continuous round-trip precision" begin
-        @test rate(Periodic(1.0e-16, 1)) == 1.0e-16
-
         # The constructor stores n*log1p(r/n) and rate() inverts with n*expm1(cv/n),
         # so the nominal rate survives a construction round-trip to within a few ulps
         # even when r/n is small (log(1+x) alone loses ~x⁻¹·eps of relative precision).

--- a/test/Rates.jl
+++ b/test/Rates.jl
@@ -88,6 +88,8 @@
     end
 
     @testset "nominal↔continuous round-trip precision" begin
+        @test rate(Periodic(1.0e-16, 1)) == 1.0e-16
+
         # The constructor stores n*log1p(r/n) and rate() inverts with n*expm1(cv/n),
         # so the nominal rate survives a construction round-trip to within a few ulps
         # even when r/n is small (log(1+x) alone loses ~x⁻¹·eps of relative precision).

--- a/test/irr.jl
+++ b/test/irr.jl
@@ -26,7 +26,8 @@ p(rate) = Periodic(rate, 1)
 
 
     @test irr([-100, 100]) ≈ p(0.0) atol = eps()
-    @test rate(irr([-1.0, 1.0 + 1.0e-12])) ≈ 1.0e-12 rtol = 1.0e-4
+    @test rate(FinanceCore._periodic_from_force(1.0e-16)) == 1.0e-16
+    @test rate(irr([-1.0, 1.0 + 1.0e-10])) ≈ 1.0e-10 rtol = 1.0e-6
     @test isnothing(irr([100, 100])) # answer is -1, but search range won't find it
 
     # test the unsolvable

--- a/test/irr.jl
+++ b/test/irr.jl
@@ -25,7 +25,8 @@ p(rate) = Periodic(rate, 1)
     @test irr(cfs, 0:50) ≈ p(0.3176680627111823)
 
 
-    @test irr([-100, 100]) ≈ p(0.0)
+    @test irr([-100, 100]) ≈ p(0.0) atol = eps()
+    @test rate(irr([-1.0, 1.0 + 1.0e-12])) ≈ 1.0e-12 rtol = 1.0e-4
     @test isnothing(irr([100, 100])) # answer is -1, but search range won't find it
 
     # test the unsolvable


### PR DESCRIPTION
## Summary
- use expm1 when converting IRR solver forces to annual effective rates
- centralize the four conversions in an internal helper
- directly test conversion of a 1e-16 force, independently of solver residual error
- retain a stable 1e-10 end-to-end IRR integration test

This improves the nominal value returned by rate() for very small IRRs. It does not materially change discount factors, which already use the stored continuous force.

## Compatibility note
The more accurate conversion can expose tiny solver residuals that exp(r) - 1 previously rounded away. For example, irr([-100, 100]) changes from an exactly zero displayed nominal rate to approximately -2.35e-17. Code using iszero(rate(irr(...))) should use isapprox with an absolute tolerance instead.

## Merge order
PR #45 rewrites the same four conversion sites and already contains #51. Merge #45 first; this PR should then be rebased onto updated main and the small conversion helper reapplied. Merging this PR first would instead require the larger #45 to resolve the overlap.

## Testing
- full FinanceCore package test suite