### PR TITLE
Make Rate addition convention independent

### DIFF
--- a/src/Rates.jl
+++ b/src/Rates.jl
@@ -435,7 +435,10 @@ forward(rate::T, from, to) where {T <: Rate} = rate
     +(T<:Real, Rate)
     +(Rate, Rate)
 
-The addition of a rate with a number will inherit the type of the `Rate`, or the first argument's type if both are `Rate`s.
+Adding a scalar changes the nominal rate in the existing compounding convention.
+Adding two `Rate`s adds their continuously compounded forces and returns a
+`Continuous` rate, making the operation independent of argument order and
+compounding representation.
 
 # Examples
 
@@ -461,12 +464,8 @@ function Base.:+(a::Real, b::Rate{N, T}) where {N, T <: Periodic}
     return Periodic(rate(b) + a, b.compounding.frequency)
 end
 
-function Base.:+(a::T, b::U) where {T <: Rate, U <: Rate}
-    a_rate = rate(a)
-    b_rate = rate(convert(a.compounding, b))
-    r = Rate(a_rate + b_rate, a.compounding)
-    return r
-end
+Base.:+(a::T, b::U) where {T <: Rate, U <: Rate} =
+    Continuous(a.continuous_value + b.continuous_value)
 
 """
     -(Rate, T<:Real)

--- a/test/Rates.jl
+++ b/test/Rates.jl
@@ -96,7 +96,7 @@
         end
 
         # arithmetic in nominal space no longer accretes conversion noise
-        @test rate(Periodic(0.01, 2) + Periodic(0.04, 2)) ≈ 0.05 rtol = 4 * eps()
+        @test rate(Periodic(0.01, 2) + 0.04) ≈ 0.05 rtol = 4 * eps()
         @test rate(Periodic(0.04, 2) - Periodic(0.01, 2)) ≈ 0.03 rtol = 4 * eps()
 
         # Float32 values stay Float32 and round-trip at Float32 precision
@@ -307,6 +307,14 @@
 
             @test p(a) + c(b) ≈ p(a) + Periodic(1)(c(b))
             @test c(a) + p(b) ≈ c(a) + Continuous()(p(b))
+
+            semiannual = Periodic(0.04, 2)
+            annual = Periodic(0.03, 1)
+            sum_rate = semiannual + annual
+            @test sum_rate isa Rate{<:Any, Continuous}
+            @test rate(sum_rate) == rate(Continuous(semiannual)) + rate(Continuous(annual))
+            @test semiannual + annual == annual + semiannual
+            @test semiannual + Continuous(annual) == Continuous(semiannual) + annual
         end
 
         @testset "multiplication" begin
@@ -346,7 +354,7 @@
             r = Periodic(0.04, 2) - Periodic(0.01, 2)
             @test r ≈ Periodic(0.03, 2)
             r = Periodic(0.04, 2) + Periodic(0.01, 2)
-            @test r ≈ Periodic(0.05, 2)
+            @test r == Continuous(Periodic(0.04, 2)) + Continuous(Periodic(0.01, 2))
 
             @test Periodic(0.04, 1) > Periodic(0.03, 2)
             @test Periodic(0.03, 1) < Periodic(0.04, 2)


### PR DESCRIPTION
## Summary
- define Rate + Rate as addition of continuous forces
- return a Continuous rate so results do not depend on operand order
- preserve existing nominal-space semantics for Rate + scalar
- update and extend rate algebra tests

## Testing
- full FinanceCore package test suite