### PR TITLE
Accept all integer compounding frequency types

### DIFF
--- a/src/Rates.jl
+++ b/src/Rates.jl
@@ -68,6 +68,8 @@ struct Periodic <: Frequency
     end
 end
 
+Periodic(frequency::Integer) = Periodic(Int(frequency))
+
 function Periodic(frequency::T) where {T <: AbstractFloat}
     f = Int(round(frequency, digits = 8))
     return Periodic(f)
@@ -236,7 +238,7 @@ end
 function Continuous(r::Rate{<:Any, <:Continuous})
     return r
 end
-function Periodic(r::Rate{<:Any, <:Frequency}, frequency::Int)
+function Periodic(r::Rate{<:Any, <:Frequency}, frequency::Integer)
     return convert.(Periodic(frequency), r)
 end
 

--- a/test/Rates.jl
+++ b/test/Rates.jl
@@ -243,6 +243,12 @@
         @test_throws ArgumentError Periodic(-2)
         @test_throws ArgumentError Periodic(0.05, 0)
         @test_throws ArgumentError Periodic(0.05, -1)
+
+        for frequency in (Int8(2), UInt16(2), Int32(2), big(2))
+            @test Periodic(frequency) == Periodic(2)
+            @test Rate(1, Periodic(frequency)) ≈ Periodic(1.0, 2)
+            @test Periodic(Continuous(0.03), frequency) ≈ Periodic(Continuous(0.03), 2)
+        end
     end
 
     @testset "discounting and accumulation" for t in [-1.3, 2.46, 6.7]


### PR DESCRIPTION
## Summary
- add a generic Integer constructor for Periodic frequencies
- accept generic Integer frequencies when converting existing rates
- cover signed, unsigned, fixed-width, and BigInt frequencies
- retain the already-fixed Rate(1, Periodic(2)) behavior on main

## Testing
- full FinanceCore package test suite