### PR TITLE
Define empty cashflow policy for IRR and PV

### DIFF
--- a/src/irr.jl
+++ b/src/irr.jl
@@ -6,6 +6,7 @@
 Calculate the internal rate of return with given timepoints. If no timepoints given, assumes equally spaced cashflows starting at time zero (0, 1, 2, ..., n).
 
 Returns a `Periodic(rate, 1)` `Rate`, or `nothing` if no root is found. Get the scalar rate by calling `rate()` on the result.
+Empty cashflow collections throw `ArgumentError`.
 
 # Example
 ```julia-repl
@@ -23,6 +24,7 @@ function internal_rate_of_return(cashflows::AbstractVector{<:Real})
 end
 
 function internal_rate_of_return(cashflows::Vector{C}) where {C <: Cashflow}
+    isempty(cashflows) && throw(ArgumentError("cashflows must not be empty"))
     # first try to quickly solve with newton's method, otherwise
     # revert to a more robust method
 
@@ -36,6 +38,7 @@ function internal_rate_of_return(cashflows::Vector{C}) where {C <: Cashflow}
 end
 
 function internal_rate_of_return(cashflows, times)
+    isempty(cashflows) && throw(ArgumentError("cashflows must not be empty"))
     # first try to quickly solve with newton's method, otherwise
     # revert to a more robust method
 

--- a/src/pv.jl
+++ b/src/pv.jl
@@ -3,6 +3,7 @@
 
 Discount the `cashflows` vector at the given `yield_model`,  with the cashflows occurring
 at the times specified in `timepoints`. If no `timepoints` given, assumes that cashflows happen at the indices of the cashflows.
+Empty cashflow collections throw `ArgumentError`.
 
 If your timepoints are dates, you can convert them into a floating point representation of the time interval using DayCounts.jl.
 
@@ -23,11 +24,13 @@ julia> present_value(Continuous(0.1), [10,20])
 
 """
 function present_value(r, x, times)
+    isempty(x) && throw(ArgumentError("cashflows must not be empty"))
     # previously tried LoopVectorization.vmapreduce, but it didn't play well with
     # dual numbers when differentiated
     return mapreduce((xi, ti) -> present_value(r, xi, ti), +, x, times)
 end
 function present_value(r, x)
+    isempty(x) && throw(ArgumentError("cashflows must not be empty"))
     return mapreduce(px -> present_value(r, last(px), first(px)), +, pairs(x))
 end
 

--- a/test/irr.jl
+++ b/test/irr.jl
@@ -3,6 +3,10 @@ p(rate) = Periodic(rate, 1)
 
 @testset "irr" begin
 
+    @test_throws ArgumentError irr(Float64[])
+    @test_throws ArgumentError irr(Float64[], Float64[])
+    @test_throws ArgumentError irr(Cashflow{Float64, Float64}[])
+
     v = [-70000, 12000, 15000, 18000, 21000, 26000]
 
     # per Excel (example comes from Excel help text)

--- a/test/present_value.jl
+++ b/test/present_value.jl
@@ -1,4 +1,8 @@
 @testset "pv" begin
+    @test_throws ArgumentError pv(0.05, Float64[])
+    @test_throws ArgumentError pv(0.05, Float64[], Float64[])
+    @test_throws ArgumentError pv(0.05, Cashflow{Float64, Float64}[])
+
     cf = [100, 100]
 
     @test pv(0.05, cf) ≈ cf[1] / 1.05 + cf[2] / 1.05^2


### PR DESCRIPTION
## Summary
- reject empty IRR inputs with ArgumentError
- reject empty PV inputs with the same public policy
- document the policy for both APIs
- cover real-valued, explicit-timepoint, and Cashflow-vector entry points

## Testing
- full FinanceCore package test suite