### PR TITLE
Make LoopVectorization dispatch local and type-safe

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,6 +6,24 @@ CurrentModule = FinanceCore
 
 Documentation for [FinanceCore](https://github.com/JuliaActuary/FinanceCore.jl).
 
+## Optional IRR vectorization
+
+Loading [LoopVectorization.jl](https://github.com/JuliaSIMD/LoopVectorization.jl)
+enables an optimized inner kernel for compatible [`irr`](@ref) inputs. Backend
+selection depends only on the arguments to each call; loading LoopVectorization
+does not change a process-global FinanceCore setting.
+
+The current public IRR solver uses the optimized kernel for dense `Float64`
+cashflow vectors when timepoints are either a dense `Float64` vector or the
+integer range created by `irr(cashflows)`. Integer, mixed-type, custom-number,
+and `Cashflow` inputs use FinanceCore's base SIMD kernel.
+
+The optimized and base kernels are numerically equivalent within floating-point
+precision. Reassociated operations and LoopVectorization's exponential
+implementation can produce differences near the last bit; pin the package
+environment and use tolerance-based comparisons when exact reproducibility is
+required across environments.
+
 ```@index
 ```
 

--- a/ext/FinanceCoreLoopVectorizationExt.jl
+++ b/ext/FinanceCoreLoopVectorizationExt.jl
@@ -4,20 +4,26 @@ using FinanceCore
 using FinanceCore: TurboBackend
 using LoopVectorization
 
+# The public IRR solver currently seeds Newton iteration with a Float64, so its
+# Float32 cashflow path falls back to SIMD. Float32 remains valid for direct and
+# future type-preserving solver calls.
 const TurboFloat = Union{Float32, Float64}
+const TurboTimes{T} = Union{StridedVector{T}, AbstractRange{Int}}
 
 FinanceCore._vectorization_backend(
     r::T,
     cashflows::StridedVector{T},
-    times::StridedVector{T},
+    times::TurboTimes{T},
 ) where {T <: TurboFloat} = TurboBackend()
 
-# @turbo implementation for TurboBackend
+# @turbo implementation for inputs that pass LoopVectorization.check_args.
+# Reassociation and LoopVectorization's exp may differ from the SIMD result by
+# approximately one ulp.
 function FinanceCore.__pv_div_pv′(
         ::TurboBackend,
         r::T,
         cashflows::StridedVector{T},
-        times::StridedVector{T},
+        times::TurboTimes{T},
     ) where {T <: TurboFloat}
     n = 0.0
     d = 0.0

--- a/ext/FinanceCoreLoopVectorizationExt.jl
+++ b/ext/FinanceCoreLoopVectorizationExt.jl
@@ -1,34 +1,29 @@
 module FinanceCoreLoopVectorizationExt
 
 using FinanceCore
-using FinanceCore: TurboBackend, VECTORIZATION_BACKEND, Cashflow, amount, timepoint
+using FinanceCore: TurboBackend
 using LoopVectorization
 
-# Set the backend to TurboBackend when this extension loads
-function __init__()
-    return VECTORIZATION_BACKEND[] = TurboBackend()
-end
+const TurboFloat = Union{Float32, Float64}
+
+FinanceCore._vectorization_backend(
+    r::T,
+    cashflows::StridedVector{T},
+    times::StridedVector{T},
+) where {T <: TurboFloat} = TurboBackend()
 
 # @turbo implementation for TurboBackend
-function FinanceCore.__pv_div_pv′(::TurboBackend, r, cashflows, times)
+function FinanceCore.__pv_div_pv′(
+    ::TurboBackend,
+    r::T,
+    cashflows::StridedVector{T},
+    times::StridedVector{T},
+) where {T <: TurboFloat}
     n = 0.0
     d = 0.0
-    @turbo warn_check_args = false for i in eachindex(cashflows)
+    @turbo for i in eachindex(cashflows)
         cf = cashflows[i]
         t = times[i]
-        a = cf * exp(-r * t)
-        n += a
-        d += a * -t
-    end
-    return n / d
-end
-
-function FinanceCore.__pv_div_pv′(::TurboBackend, r, cashflows::Vector{C}) where {C <: Cashflow}
-    n = 0.0
-    d = 0.0
-    @turbo warn_check_args = false for i in eachindex(cashflows)
-        cf = amount(cashflows[i])
-        t = timepoint(cashflows[i])
         a = cf * exp(-r * t)
         n += a
         d += a * -t

--- a/ext/FinanceCoreLoopVectorizationExt.jl
+++ b/ext/FinanceCoreLoopVectorizationExt.jl
@@ -14,11 +14,11 @@ FinanceCore._vectorization_backend(
 
 # @turbo implementation for TurboBackend
 function FinanceCore.__pv_div_pv′(
-    ::TurboBackend,
-    r::T,
-    cashflows::StridedVector{T},
-    times::StridedVector{T},
-) where {T <: TurboFloat}
+        ::TurboBackend,
+        r::T,
+        cashflows::StridedVector{T},
+        times::StridedVector{T},
+    ) where {T <: TurboFloat}
     n = 0.0
     d = 0.0
     @turbo for i in eachindex(cashflows)

--- a/src/irr.jl
+++ b/src/irr.jl
@@ -115,22 +115,22 @@ abstract type VectorizationBackend end
 struct SimdBackend <: VectorizationBackend end
 struct TurboBackend <: VectorizationBackend end
 
-# Global backend setting - extensions can change this
-const VECTORIZATION_BACKEND = Ref{VectorizationBackend}(SimdBackend())
+_vectorization_backend(r, cashflows, times) = SimdBackend()
+_vectorization_backend(r, cashflows::Vector{C}) where {C <: Cashflow} = SimdBackend()
 
 # an internal function which calculates the
 # present value and it's derivative in one pass
 # for use in newton's method
 #
-# Dispatches to the appropriate backend. When LoopVectorization
-# is loaded, the extension sets VECTORIZATION_BACKEND to TurboBackend()
-# and provides a faster @turbo-based implementation.
+# Dispatches to the appropriate backend based on the input types. The
+# LoopVectorization extension opts supported dense floating-point arrays into its
+# turbo kernel without changing process-global state.
 function __pv_div_pv′(r, cashflows, times)
-    return __pv_div_pv′(VECTORIZATION_BACKEND[], r, cashflows, times)
+    return __pv_div_pv′(_vectorization_backend(r, cashflows, times), r, cashflows, times)
 end
 
 function __pv_div_pv′(r, cashflows::Vector{C}) where {C <: Cashflow}
-    return __pv_div_pv′(VECTORIZATION_BACKEND[], r, cashflows)
+    return __pv_div_pv′(_vectorization_backend(r, cashflows), r, cashflows)
 end
 
 # Base @simd implementation

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,13 +14,21 @@ using Aqua
     Aqua.test_all(FinanceCore)
 end
 
-# Load LoopVectorization last: its extension flips VECTORIZATION_BACKEND for the
-# remainder of the session, so these exercise the @turbo irr kernels.
+# Loading LoopVectorization adds narrow, argument-based methods without mutating
+# a process-global backend.
 using LoopVectorization
 @testset "LoopVectorization extension" begin
-    @test FinanceCore.VECTORIZATION_BACKEND[] isa FinanceCore.TurboBackend
+    @test !isdefined(FinanceCore, :VECTORIZATION_BACKEND)
+    @test FinanceCore._vectorization_backend(0.1, [-100.0, 110.0], [0.0, 1.0]) isa
+        FinanceCore.TurboBackend
+    @test FinanceCore._vectorization_backend(0.1, [-100, 110], [0, 1]) isa
+        FinanceCore.SimdBackend
+    @test FinanceCore._vectorization_backend(
+        0.1,
+        [Cashflow(-100.0, 0.0), Cashflow(110.0, 1.0)],
+    ) isa FinanceCore.SimdBackend
     @test irr([-100, 110]) ≈ Periodic(0.1, 1)
-    @test irr([-100, 110], [0, 1]) ≈ Periodic(0.1, 1)
+    @test irr([-100.0, 110.0], [0.0, 1.0]) ≈ Periodic(0.1, 1)
     @test isnothing(irr([0.0, 0.0, 0.0]))
     @test irr([Cashflow(-100.0, 0.0), Cashflow(110.0, 1.0)]) ≈ Periodic(0.1, 1)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,12 +21,21 @@ using LoopVectorization
     @test !isdefined(FinanceCore, :VECTORIZATION_BACKEND)
     @test FinanceCore._vectorization_backend(0.1, [-100.0, 110.0], [0.0, 1.0]) isa
         FinanceCore.TurboBackend
+    @test FinanceCore._vectorization_backend(0.1, [-100.0, 110.0], 0:1) isa
+        FinanceCore.TurboBackend
     @test FinanceCore._vectorization_backend(0.1, [-100, 110], [0, 1]) isa
         FinanceCore.SimdBackend
     @test FinanceCore._vectorization_backend(
         0.1,
         [Cashflow(-100.0, 0.0), Cashflow(110.0, 1.0)],
     ) isa FinanceCore.SimdBackend
+
+    cfs = [-100.0, 110.0]
+    times = 0:1
+    simd_result = FinanceCore.__pv_div_pv′(FinanceCore.SimdBackend(), 0.1, cfs, times)
+    turbo_result = FinanceCore.__pv_div_pv′(FinanceCore.TurboBackend(), 0.1, cfs, times)
+    @test simd_result ≈ turbo_result rtol = 1.0e-13
+
     @test irr([-100, 110]) ≈ Periodic(0.1, 1)
     @test irr([-100.0, 110.0], [0.0, 1.0]) ≈ Periodic(0.1, 1)
     @test isnothing(irr([0.0, 0.0, 0.0]))


### PR DESCRIPTION
## Summary
- replace the mutable process-global vectorization backend with pure argument-type dispatch
- retain turbo acceleration for dense Float64 vectors with either dense Float64 time vectors or the integer ranges used by irr(cashflows)
- keep integer, mixed, custom-number, and Cashflow inputs on the base SIMD implementation
- remove the Cashflow turbo method, whose arguments fail LoopVectorization.check_args and therefore never vectorized
- restore LoopVectorization argument diagnostics and test dispatch boundaries plus SIMD/turbo equivalence
- document backend selection, fallback behavior, and numerical reproducibility expectations

## Behavior and compatibility notes
- loading LoopVectorization no longer mutates process-global FinanceCore state
- VECTORIZATION_BACKEND is removed; it was internal in practice and no FinanceModels or ActuaryUtilities references were found
- turbo and SIMD may differ at approximately the last ulp because of reassociation and LoopVectorization exp; the Newton-step quotient can amplify this slightly near a root
- Float32 is a valid internal turbo signature, although the current public solver uses a Float64 Newton seed and therefore routes Float32 cashflow inputs through SIMD

This is suitable for a patch release. The repository currently has no changelog file, so these compatibility notes are recorded here.

## Merge order
PR #45 rewrites the same IRR internals and already contains #51. Merge #45 first, then rebase this PR onto updated main and reapply the argument-based backend selection.

## Testing
- full FinanceCore package test suite
- explicit UnitRange turbo-dispatch regression
- direct SIMD/turbo kernel comparison with rtol 1e-13
- Documenter build including doctests and cross-reference checks